### PR TITLE
updated for esbuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.aws-sam

--- a/hello-world/app.js
+++ b/hello-world/app.js
@@ -1,0 +1,11 @@
+import { Statement } from './dynamo.js'
+
+export async function lambdaHandler(event) {
+
+    const data = await Statement('SELECT * FROM products')
+    const response = {
+        statusCode: 200,
+        body: JSON.stringify(data)
+    };
+    return response;
+}

--- a/hello-world/dynamo.js
+++ b/hello-world/dynamo.js
@@ -1,0 +1,21 @@
+import { DynamoDBClient, ExecuteStatementCommand } from "@aws-sdk/client-dynamodb";
+const { unmarshall } = require("@aws-sdk/util-dynamodb");
+
+const DynamoClient = new DynamoDBClient({
+    endpoint: 'http://dynamo-local:8000'
+})
+
+const Statement = async (Statement) => {
+    let response = {}
+    try {
+        const command = new ExecuteStatementCommand({ Statement })
+        response = await DynamoClient.send(command).then(data => {
+            return data.Items.map(i => unmarshall(i))
+        })
+    } catch (error) {
+        response  = { error }
+    }
+    return response
+}
+
+export { Statement }

--- a/hello-world/package-lock.json
+++ b/hello-world/package-lock.json
@@ -1,0 +1,2453 @@
+{
+    "name": "hello-world-function",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "hello-world-function",
+            "dependencies": {
+                "@aws-sdk/client-dynamodb": "^3.211.0",
+                "@aws-sdk/util-dynamodb": "^3.214.0",
+                "esbuild": "^0.15.14"
+            }
+        },
+        "node_modules/@aws-crypto/ie11-detection": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "dependencies": {
+                "@aws-crypto/ie11-detection": "^2.0.0",
+                "@aws-crypto/sha256-js": "^2.0.0",
+                "@aws-crypto/supports-web-crypto": "^2.0.0",
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "dependencies": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "dependencies": {
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+            "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.110.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/tslib": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        },
+        "node_modules/@aws-sdk/abort-controller": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
+            "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-dynamodb": {
+            "version": "3.214.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.214.0.tgz",
+            "integrity": "sha512-aCu5PTS3uyy63X9Gz8oUbAlmLeh+N4xOvl46Nk2se1EhrFlIogoXfV3MhKNgqzOfVTgII1u6mq9prMFmEjCgvQ==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/client-sts": "3.213.0",
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/credential-provider-node": "3.212.0",
+                "@aws-sdk/fetch-http-handler": "3.212.0",
+                "@aws-sdk/hash-node": "3.212.0",
+                "@aws-sdk/invalid-dependency": "3.212.0",
+                "@aws-sdk/middleware-content-length": "3.212.0",
+                "@aws-sdk/middleware-endpoint": "3.212.0",
+                "@aws-sdk/middleware-endpoint-discovery": "3.212.0",
+                "@aws-sdk/middleware-host-header": "3.212.0",
+                "@aws-sdk/middleware-logger": "3.212.0",
+                "@aws-sdk/middleware-recursion-detection": "3.212.0",
+                "@aws-sdk/middleware-retry": "3.212.0",
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/middleware-signing": "3.212.0",
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/middleware-user-agent": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/node-http-handler": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/smithy-client": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+                "@aws-sdk/util-defaults-mode-node": "3.212.0",
+                "@aws-sdk/util-endpoints": "3.212.0",
+                "@aws-sdk/util-user-agent-browser": "3.212.0",
+                "@aws-sdk/util-user-agent-node": "3.212.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "@aws-sdk/util-waiter": "3.212.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.212.0.tgz",
+            "integrity": "sha512-b9lFI8Uz6YxIzAlS2uq62y5fX097lwcdkiq2N8YN2U7YgHQaKMIFnV8ZqkDdhZi2eUKwhSdUZzQy0tF6en2Ubg==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/fetch-http-handler": "3.212.0",
+                "@aws-sdk/hash-node": "3.212.0",
+                "@aws-sdk/invalid-dependency": "3.212.0",
+                "@aws-sdk/middleware-content-length": "3.212.0",
+                "@aws-sdk/middleware-endpoint": "3.212.0",
+                "@aws-sdk/middleware-host-header": "3.212.0",
+                "@aws-sdk/middleware-logger": "3.212.0",
+                "@aws-sdk/middleware-recursion-detection": "3.212.0",
+                "@aws-sdk/middleware-retry": "3.212.0",
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/middleware-user-agent": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/node-http-handler": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/smithy-client": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+                "@aws-sdk/util-defaults-mode-node": "3.212.0",
+                "@aws-sdk/util-endpoints": "3.212.0",
+                "@aws-sdk/util-user-agent-browser": "3.212.0",
+                "@aws-sdk/util-user-agent-node": "3.212.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.212.0.tgz",
+            "integrity": "sha512-Co0AU+y9KEAZUraT36ttFZlmwARsr82q2nQji5E8zg3zlUHtqGvMJqxArudz3iOb2E9WRi75MwAQmLO2xEk45A==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/fetch-http-handler": "3.212.0",
+                "@aws-sdk/hash-node": "3.212.0",
+                "@aws-sdk/invalid-dependency": "3.212.0",
+                "@aws-sdk/middleware-content-length": "3.212.0",
+                "@aws-sdk/middleware-endpoint": "3.212.0",
+                "@aws-sdk/middleware-host-header": "3.212.0",
+                "@aws-sdk/middleware-logger": "3.212.0",
+                "@aws-sdk/middleware-recursion-detection": "3.212.0",
+                "@aws-sdk/middleware-retry": "3.212.0",
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/middleware-user-agent": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/node-http-handler": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/smithy-client": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+                "@aws-sdk/util-defaults-mode-node": "3.212.0",
+                "@aws-sdk/util-endpoints": "3.212.0",
+                "@aws-sdk/util-user-agent-browser": "3.212.0",
+                "@aws-sdk/util-user-agent-node": "3.212.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sts": {
+            "version": "3.213.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.213.0.tgz",
+            "integrity": "sha512-MCjtLaYVQJLIMeLubDc4yRjSyVVTOebKxhY4ix4cfpSA6X4jMc4gRY2eu4eja3qoISfHq/Ikrkxx9DD1+n1azg==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/credential-provider-node": "3.212.0",
+                "@aws-sdk/fetch-http-handler": "3.212.0",
+                "@aws-sdk/hash-node": "3.212.0",
+                "@aws-sdk/invalid-dependency": "3.212.0",
+                "@aws-sdk/middleware-content-length": "3.212.0",
+                "@aws-sdk/middleware-endpoint": "3.212.0",
+                "@aws-sdk/middleware-host-header": "3.212.0",
+                "@aws-sdk/middleware-logger": "3.212.0",
+                "@aws-sdk/middleware-recursion-detection": "3.212.0",
+                "@aws-sdk/middleware-retry": "3.212.0",
+                "@aws-sdk/middleware-sdk-sts": "3.212.0",
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/middleware-signing": "3.212.0",
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/middleware-user-agent": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/node-http-handler": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/smithy-client": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+                "@aws-sdk/util-defaults-mode-node": "3.212.0",
+                "@aws-sdk/util-endpoints": "3.212.0",
+                "@aws-sdk/util-user-agent-browser": "3.212.0",
+                "@aws-sdk/util-user-agent-node": "3.212.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "fast-xml-parser": "4.0.11",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/config-resolver": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.212.0.tgz",
+            "integrity": "sha512-hIP/Izpv6GCsDTnHCd/X9Ro7Mw5le+gr2VbkZHWR0c8+3xZWp8N5S0QnUBogF3Dv2KwPbmHP+bs/vqqo3miUjQ==",
+            "dependencies": {
+                "@aws-sdk/signature-v4": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.212.0.tgz",
+            "integrity": "sha512-HNYoqetLqTxwl0Grl4ez8Dx3I3hJfskxH2PTHYI1/iAqrY/gSB2oBOusvBeksbYrScnQM2IGqEcMJ4lzGLOH+w==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-imds": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.212.0.tgz",
+            "integrity": "sha512-Bg7cX2N5pJ//ft3Y8HWtpDSEMMgRTNMaNlIvTlDbAKYp7HBZRWSf9ZJnz2slT7qbyaJyRP5pSJC4XRm83g4leA==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.212.0.tgz",
+            "integrity": "sha512-H7qRIP8qV7tRrCSJx2p5oQVMJASQWZUmi4l699hDMejmCO/m4pUMQFmWn2FXtZv8gTfzlkmp3wMixD5jnfL7pw==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.212.0",
+                "@aws-sdk/credential-provider-imds": "3.212.0",
+                "@aws-sdk/credential-provider-sso": "3.212.0",
+                "@aws-sdk/credential-provider-web-identity": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.212.0.tgz",
+            "integrity": "sha512-T44hoU3GCYHS+4GDVs7S/v2bBHmmYpnPayQsYXhDElQKXP0cFzQ78F8et4IU5lM94hwK+ISRQPrKaq4p77evkw==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.212.0",
+                "@aws-sdk/credential-provider-imds": "3.212.0",
+                "@aws-sdk/credential-provider-ini": "3.212.0",
+                "@aws-sdk/credential-provider-process": "3.212.0",
+                "@aws-sdk/credential-provider-sso": "3.212.0",
+                "@aws-sdk/credential-provider-web-identity": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.212.0.tgz",
+            "integrity": "sha512-bGaVKSm5Tf5VZtlM2V6k+M9nSKzlb14ldCcH0PGGMaK/dqnEJDVSxXPu3fWyomaxbLt7Is3AUMh6L2bq3kuXyA==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.212.0.tgz",
+            "integrity": "sha512-OGatVUnWLp7PePs2H2RyYmTrwurl0tAfW+LWfVAPgYyvi2RQgTmSK5LJ3pXKxz3TvaSHkCvsT0NWNqdWY+iKWQ==",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/token-providers": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.212.0.tgz",
+            "integrity": "sha512-zPF3KiVT14aeu4cRyEUelAJEAzFp++9ULLigQXhKBbFYaiOZMAHKRASO/WUK1ixYBC+ax4G1rbihLfQimXMtVA==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/endpoint-cache": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
+            "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
+            "dependencies": {
+                "mnemonist": "0.38.3",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/fetch-http-handler": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
+            "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/querystring-builder": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/hash-node": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.212.0.tgz",
+            "integrity": "sha512-pwZkz83EvXHGURBYjBYS7Cr+gSr6pi23RDlP/aXREjJGs9QUQyixBh78oX5a3p6bB8JeizPcZS1dXKJ9OKCHAw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/invalid-dependency": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.212.0.tgz",
+            "integrity": "sha512-zKVx+4Silmsr5Nvv9aGL5FmuHvdP9Dcvy/22fmWa3RRvCSNRpvFDeXtcDB5FvNpbWbO+qJyGj/OeqB/XejV13w==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/is-array-buffer": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+            "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-content-length": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.212.0.tgz",
+            "integrity": "sha512-gR6jeKGYNYqNLFRcuX3vv5PN1POLlB/9LDVYl3k/NNaCg8L1EKqqEtG84Gmn1AXH+2s6zMNs+gt5ygeqZQe2Cw==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-endpoint": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.212.0.tgz",
+            "integrity": "sha512-6ntKYehjxLun8hPXIPHSI2pGr/pHuQ6jcyO5wBq1kydSIIGiESl8H84DEt+yRvroCiYgbU+I8cACnRE0uv0bLA==",
+            "dependencies": {
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/signature-v4": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.212.0.tgz",
+            "integrity": "sha512-CviyDda9MFM70v0hVQ8Ns6CJrOfOQQe+h0C/f8C4nzj31TmojJFRxnS0MmonZQcHPpyWH2Zt48RQhA9mui+ROQ==",
+            "dependencies": {
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/endpoint-cache": "3.208.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.212.0.tgz",
+            "integrity": "sha512-W00mxzK2OXy91Ncxri3cZJIxxSBzE72bX8FDa3xgC0ujbj49lw+rol6aV/Fw8Nda3CZ5xxulvJ4sXHt2eOtXSA==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.212.0.tgz",
+            "integrity": "sha512-BSQqzKp4abf2wXvJEstB0zdr68yJMZXA14h53eSvtzykZLfvvFixR1nyVgKq+PKm1VaJ2fuZr10tjWRVQg1pYA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.212.0.tgz",
+            "integrity": "sha512-ATHPNtnd7nlm0jRXvr/c2xbxcna5ZGXEWTM5tUjIflOK9Rl3PCRce/hoQnHs45kv4l3daC53sPuRvTQ8O7K67A==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-retry": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.212.0.tgz",
+            "integrity": "sha512-lIi/JkYXalY6CYw2dJbQ/Xo64Ah3wfJ63BMTFQHQk1htnIDBnLd9a6ng96JgXJQMSO4ZEqRW/709NBlC157hbw==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/service-error-classification": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-sts": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.212.0.tgz",
+            "integrity": "sha512-IcMfno3RJEXXS1Ch5lY0hgdSkGn9XW9m3XoKu1DjhEqR34ENDzvUmEN2PimIcZnz+9W59CU9UAMs/amRhwhlmw==",
+            "dependencies": {
+                "@aws-sdk/middleware-signing": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/signature-v4": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-serde": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.212.0.tgz",
+            "integrity": "sha512-KwRpwi/8vNDV0l8uvu1DPk0q3WR2pnp9VtUNZ6u9zU54hvVL+Z1PtQh/WfzJzNvtCHvtc/gVMs3Daqb/Ecrm5Q==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-signing": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.212.0.tgz",
+            "integrity": "sha512-pth95aEsxqQO0lrRAHZNVI5hrMtA14nEUPFjiLaXtOssZrjD6mBzXPRy1nKob6XWXOp/Vy0mnyI/FT/NnMflFw==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/signature-v4": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-stack": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.212.0.tgz",
+            "integrity": "sha512-AZ5f9ChioHsxGUojlzqI57sYyM9oW9SN/7AuiNafXU02j9jw7DKiYRn43lRUhgYnb/REhedHA5SsqIBF5eut/w==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.212.0.tgz",
+            "integrity": "sha512-CVSY2kt+RaP6CVqSKp+1sPUAQFusTLZLFHVK0YPFzcIySJMqJC0l0/BzLhaIf5Bs3JHa/VGym8oDpp881yimHA==",
+            "dependencies": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-config-provider": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.212.0.tgz",
+            "integrity": "sha512-8AfOEDPe/D9DccUgredYg07GH2jrw07FCTyA1Pug5Hgbas7w14zbhLyQB0l6gcOJEuh34e/7oV9hN3s1hctnJg==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/node-http-handler": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
+            "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/querystring-builder": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/property-provider": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.212.0.tgz",
+            "integrity": "sha512-NMCIABfw3VZ7Vtn6iSeZRuSToRLxIHq0eGoUgO7T4fUp3U5vqYt28A5UY65KB9ifUPpNSllEG3EhEqs5qFw5+w==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/protocol-http": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+            "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-builder": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+            "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/querystring-parser": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.212.0.tgz",
+            "integrity": "sha512-ttarfAHMOYKgFHeBdgXID9SlNS7erH4gavN3fvf5R1RliCytUnzsTTvqa7CmVBFy0Xc/2yA+/6FFDKlOsS8tRg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/service-error-classification": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.212.0.tgz",
+            "integrity": "sha512-jCv+uuFq4yGjP8FoCmoOGqnKNHHREDOFf7OxVSCluGMg2LXHfGxxqkqNFJlT3p+QdEp323GSWFY+PUsMJy7BLQ==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/shared-ini-file-loader": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.212.0.tgz",
+            "integrity": "sha512-wKWqCA1oU57V//D3uAjQKGGj6rm6YKH4pWIU38Ypb/xNafiB7C51KtwpQVsS2HCNfmGrD03sGLKEZCSy9jvIlA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
+            "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-hex-encoding": "3.201.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/smithy-client": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.212.0.tgz",
+            "integrity": "sha512-dQUlM/eltp9JVEVQWGxU/6Or8jGQWK5mgmbP+BUHkfDgoMIeOFksIYon211KhE18EjoGgav1mr4/HHlcnekI2w==",
+            "dependencies": {
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.212.0.tgz",
+            "integrity": "sha512-pTe4PM14b58nbfvIP9B0zW5dUIxEb/ALVzSLuxpJwJRI51E5QZmXJMT3P77MUd6niqKw0cRrnEHIgznD67JHSg==",
+            "dependencies": {
+                "@aws-sdk/client-sso-oidc": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+            "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/url-parser": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.212.0.tgz",
+            "integrity": "sha512-mTUQQRcVYqur7aHDuDMDKxN7Yr/5kIZB1RtMjIwtimTcf7TZaskN6sLTPo42YgASM6XQQhJECZaOE7Ow16i6Mg==",
+            "dependencies": {
+                "@aws-sdk/querystring-parser": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-base64": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+            "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-browser": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+            "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-body-length-node": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+            "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-buffer-from": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+            "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "dependencies": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-config-provider": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+            "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.212.0.tgz",
+            "integrity": "sha512-tAs9+/lTtil545kyCqy7qjnnCq4S2S+4kBhHXgwRNPT85Nx5XCEEheWH6VZ45YufRaiRNFfX0n+odDwzDaev6g==",
+            "dependencies": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-defaults-mode-node": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.212.0.tgz",
+            "integrity": "sha512-fNl1IDqn1mAoiM2Xv5KGAczXHy2+tPlouunIEePnQKTq0pzT3WqR13qleTfu1EcEz1oyGnDRoK91aP61Jxh3OQ==",
+            "dependencies": {
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/credential-provider-imds": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-dynamodb": {
+            "version": "3.214.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.214.0.tgz",
+            "integrity": "sha512-IsBJkNsMRwb8mtr8QYSXXPud0WG1pUD8hCBilWpxTat4Yr23aANhJX8ti1S4ks/iWU7AYjq/aSkSXH3cEkoVLA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.212.0.tgz",
+            "integrity": "sha512-/ADfvrZwhzUphre3pliO290IFOflvHyBBEaKn9WfRQ5veZxl+CuOEjxkwTJfHUrfWbh+xpCuOewWVLCptmoC4A==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-hex-encoding": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+            "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-middleware": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
+            "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-uri-escape": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+            "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.212.0.tgz",
+            "integrity": "sha512-xXz16ge9NdKCwlD+952rfvgHdDe+pbCavbVMNdR60joHq5KYGR1e02l0LRNVe48/C9dAo2ezeJ+YnTPaw3Yl8Q==",
+            "dependencies": {
+                "@aws-sdk/types": "3.212.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.212.0.tgz",
+            "integrity": "sha512-HE8VwtMtTXGkwUjryNpy+qyg7wrQxCGplDP59yo0YVn86B5f9nhRi/2jRAsKo9yf94iP7PXAz65TY9+KJC8UIg==",
+            "dependencies": {
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-browser": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+            "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "dependencies": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "node_modules/@aws-sdk/util-utf8-node": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+            "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "dependencies": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-waiter": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.212.0.tgz",
+            "integrity": "sha512-TsmNpXpefq414PrHWKO35e5YFGB/MyQBZ6Ia8+hs6wZgd7rrUFghC4yjn8eCRpnfpdegEsWGcQZ/qeyMafgvcg==",
+            "dependencies": {
+                "@aws-sdk/abort-controller": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.14.tgz",
+            "integrity": "sha512-+Rb20XXxRGisNu2WmNKk+scpanb7nL5yhuI1KR9wQFiC43ddPj/V1fmNyzlFC9bKiG4mYzxW7egtoHVcynr+OA==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.14.tgz",
+            "integrity": "sha512-eQi9rosGNVQFJyJWV0HCA5WZae/qWIQME7s8/j8DMvnylfBv62Pbu+zJ2eUDqNf2O4u3WB+OEXyfkpBoe194sg==",
+            "cpu": [
+                "loong64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+        },
+        "node_modules/esbuild": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.14.tgz",
+            "integrity": "sha512-pJN8j42fvWLFWwSMG4luuupl2Me7mxciUOsMegKvwCmhEbJ2covUdFnihxm0FMIBV+cbwbtMoHgMCCI+pj1btQ==",
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/android-arm": "0.15.14",
+                "@esbuild/linux-loong64": "0.15.14",
+                "esbuild-android-64": "0.15.14",
+                "esbuild-android-arm64": "0.15.14",
+                "esbuild-darwin-64": "0.15.14",
+                "esbuild-darwin-arm64": "0.15.14",
+                "esbuild-freebsd-64": "0.15.14",
+                "esbuild-freebsd-arm64": "0.15.14",
+                "esbuild-linux-32": "0.15.14",
+                "esbuild-linux-64": "0.15.14",
+                "esbuild-linux-arm": "0.15.14",
+                "esbuild-linux-arm64": "0.15.14",
+                "esbuild-linux-mips64le": "0.15.14",
+                "esbuild-linux-ppc64le": "0.15.14",
+                "esbuild-linux-riscv64": "0.15.14",
+                "esbuild-linux-s390x": "0.15.14",
+                "esbuild-netbsd-64": "0.15.14",
+                "esbuild-openbsd-64": "0.15.14",
+                "esbuild-sunos-64": "0.15.14",
+                "esbuild-windows-32": "0.15.14",
+                "esbuild-windows-64": "0.15.14",
+                "esbuild-windows-arm64": "0.15.14"
+            }
+        },
+        "node_modules/esbuild-android-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.14.tgz",
+            "integrity": "sha512-HuilVIb4rk9abT4U6bcFdU35UHOzcWVGLSjEmC58OVr96q5UiRqzDtWjPlCMugjhgUGKEs8Zf4ueIvYbOStbIg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-android-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.14.tgz",
+            "integrity": "sha512-/QnxRVxsR2Vtf3XottAHj7hENAMW2wCs6S+OZcAbc/8nlhbAL/bCQRCVD78VtI5mdwqWkVi3wMqM94kScQCgqg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.14.tgz",
+            "integrity": "sha512-ToNuf1uifu8hhwWvoZJGCdLIX/1zpo8cOGnT0XAhDQXiKOKYaotVNx7pOVB1f+wHoWwTLInrOmh3EmA7Fd+8Vg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-darwin-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.14.tgz",
+            "integrity": "sha512-KgGP+y77GszfYJgceO0Wi/PiRtYo5y2Xo9rhBUpxTPaBgWDJ14gqYN0+NMbu+qC2fykxXaipHxN4Scaj9tUS1A==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.14.tgz",
+            "integrity": "sha512-xr0E2n5lyWw3uFSwwUXHc0EcaBDtsal/iIfLioflHdhAe10KSctV978Te7YsfnsMKzcoGeS366+tqbCXdqDHQA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-freebsd-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.14.tgz",
+            "integrity": "sha512-8XH96sOQ4b1LhMlO10eEWOjEngmZ2oyw3pW4o8kvBcpF6pULr56eeYVP5radtgw54g3T8nKHDHYEI5AItvskZg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-32": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.14.tgz",
+            "integrity": "sha512-6ssnvwaTAi8AzKN8By2V0nS+WF5jTP7SfuK6sStGnDP7MCJo/4zHgM9oE1eQTS2jPmo3D673rckuCzRlig+HMA==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.14.tgz",
+            "integrity": "sha512-ONySx3U0wAJOJuxGUlXBWxVKFVpWv88JEv0NZ6NlHknmDd1yCbf4AEdClSgLrqKQDXYywmw4gYDvdLsS6z0hcw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.14.tgz",
+            "integrity": "sha512-D2LImAIV3QzL7lHURyCHBkycVFbKwkDb1XEUWan+2fb4qfW7qAeUtul7ZIcIwFKZgPcl+6gKZmvLgPSj26RQ2Q==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.14.tgz",
+            "integrity": "sha512-kle2Ov6a1e5AjlHlMQl1e+c4myGTeggrRzArQFmWp6O6JoqqB9hT+B28EW4tjFWgV/NxUq46pWYpgaWXsXRPAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-mips64le": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.14.tgz",
+            "integrity": "sha512-FVdMYIzOLXUq+OE7XYKesuEAqZhmAIV6qOoYahvUp93oXy0MOVTP370ECbPfGXXUdlvc0TNgkJa3YhEwyZ6MRA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-ppc64le": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.14.tgz",
+            "integrity": "sha512-2NzH+iuzMDA+jjtPjuIz/OhRDf8tzbQ1tRZJI//aT25o1HKc0reMMXxKIYq/8nSHXiJSnYV4ODzTiv45s+h73w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-riscv64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.14.tgz",
+            "integrity": "sha512-VqxvutZNlQxmUNS7Ac+aczttLEoHBJ9e3OYGqnULrfipRvG97qLrAv9EUY9iSrRKBqeEbSvS9bSfstZqwz0T4Q==",
+            "cpu": [
+                "riscv64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-linux-s390x": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.14.tgz",
+            "integrity": "sha512-+KVHEUshX5n6VP6Vp/AKv9fZIl5kr2ph8EUFmQUJnDpHwcfTSn2AQgYYm0HTBR2Mr4d0Wlr0FxF/Cs5pbFgiOw==",
+            "cpu": [
+                "s390x"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-netbsd-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.14.tgz",
+            "integrity": "sha512-6D/dr17piEgevIm1xJfZP2SjB9Z+g8ERhNnBdlZPBWZl+KSPUKLGF13AbvC+nzGh8IxOH2TyTIdRMvKMP0nEzQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-openbsd-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.14.tgz",
+            "integrity": "sha512-rREQBIlMibBetgr2E9Lywt2Qxv2ZdpmYahR4IUlAQ1Efv/A5gYdO0/VIN3iowDbCNTLxp0bb57Vf0LFcffD6kA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-sunos-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.14.tgz",
+            "integrity": "sha512-DNVjSp/BY4IfwtdUAvWGIDaIjJXY5KI4uD82+15v6k/w7px9dnaDaJJ2R6Mu+KCgr5oklmFc0KjBjh311Gxl9Q==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-32": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.14.tgz",
+            "integrity": "sha512-pHBWrcA+/oLgvViuG9FO3kNPO635gkoVrRQwe6ZY1S0jdET07xe2toUvQoJQ8KT3/OkxqUasIty5hpuKFLD+eg==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.14.tgz",
+            "integrity": "sha512-CszIGQVk/P8FOS5UgAH4hKc9zOaFo69fe+k1rqgBHx3CSK3Opyk5lwYriIamaWOVjBt7IwEP6NALz+tkVWdFog==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/esbuild-windows-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.14.tgz",
+            "integrity": "sha512-KW9W4psdZceaS9A7Jsgl4WialOznSURvqX/oHZk3gOP7KbjtHLSsnmSvNdzagGJfxbAe30UVGXRe8q8nDsOSQw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+            "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "dependencies": {
+                "strnum": "^1.0.5"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            },
+            "funding": {
+                "type": "paypal",
+                "url": "https://paypal.me/naturalintelligence"
+            }
+        },
+        "node_modules/mnemonist": {
+            "version": "0.38.3",
+            "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+            "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+            "dependencies": {
+                "obliterator": "^1.6.1"
+            }
+        },
+        "node_modules/obliterator": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+            "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
+        },
+        "node_modules/strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
+        "node_modules/tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
+        "node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        }
+    },
+    "dependencies": {
+        "@aws-crypto/ie11-detection": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+            "requires": {
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/sha256-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+            "requires": {
+                "@aws-crypto/ie11-detection": "^2.0.0",
+                "@aws-crypto/sha256-js": "^2.0.0",
+                "@aws-crypto/supports-web-crypto": "^2.0.0",
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/sha256-js": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+            "requires": {
+                "@aws-crypto/util": "^2.0.0",
+                "@aws-sdk/types": "^3.1.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/supports-web-crypto": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+            "requires": {
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-crypto/util": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+            "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+            "requires": {
+                "@aws-sdk/types": "^3.110.0",
+                "@aws-sdk/util-utf8-browser": "^3.0.0",
+                "tslib": "^1.11.1"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
+            }
+        },
+        "@aws-sdk/abort-controller": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.212.0.tgz",
+            "integrity": "sha512-mXeBSuDi0Fpul4zk9VH2z0VKN+/+6hyJ9SXSRhn3LpMcyj3GeZtXyTB2wCsfxXYGxeGbV+bIzbPbhZza6wNfWg==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/client-dynamodb": {
+            "version": "3.214.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.214.0.tgz",
+            "integrity": "sha512-aCu5PTS3uyy63X9Gz8oUbAlmLeh+N4xOvl46Nk2se1EhrFlIogoXfV3MhKNgqzOfVTgII1u6mq9prMFmEjCgvQ==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/client-sts": "3.213.0",
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/credential-provider-node": "3.212.0",
+                "@aws-sdk/fetch-http-handler": "3.212.0",
+                "@aws-sdk/hash-node": "3.212.0",
+                "@aws-sdk/invalid-dependency": "3.212.0",
+                "@aws-sdk/middleware-content-length": "3.212.0",
+                "@aws-sdk/middleware-endpoint": "3.212.0",
+                "@aws-sdk/middleware-endpoint-discovery": "3.212.0",
+                "@aws-sdk/middleware-host-header": "3.212.0",
+                "@aws-sdk/middleware-logger": "3.212.0",
+                "@aws-sdk/middleware-recursion-detection": "3.212.0",
+                "@aws-sdk/middleware-retry": "3.212.0",
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/middleware-signing": "3.212.0",
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/middleware-user-agent": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/node-http-handler": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/smithy-client": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+                "@aws-sdk/util-defaults-mode-node": "3.212.0",
+                "@aws-sdk/util-endpoints": "3.212.0",
+                "@aws-sdk/util-user-agent-browser": "3.212.0",
+                "@aws-sdk/util-user-agent-node": "3.212.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "@aws-sdk/util-waiter": "3.212.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            }
+        },
+        "@aws-sdk/client-sso": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.212.0.tgz",
+            "integrity": "sha512-b9lFI8Uz6YxIzAlS2uq62y5fX097lwcdkiq2N8YN2U7YgHQaKMIFnV8ZqkDdhZi2eUKwhSdUZzQy0tF6en2Ubg==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/fetch-http-handler": "3.212.0",
+                "@aws-sdk/hash-node": "3.212.0",
+                "@aws-sdk/invalid-dependency": "3.212.0",
+                "@aws-sdk/middleware-content-length": "3.212.0",
+                "@aws-sdk/middleware-endpoint": "3.212.0",
+                "@aws-sdk/middleware-host-header": "3.212.0",
+                "@aws-sdk/middleware-logger": "3.212.0",
+                "@aws-sdk/middleware-recursion-detection": "3.212.0",
+                "@aws-sdk/middleware-retry": "3.212.0",
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/middleware-user-agent": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/node-http-handler": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/smithy-client": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+                "@aws-sdk/util-defaults-mode-node": "3.212.0",
+                "@aws-sdk/util-endpoints": "3.212.0",
+                "@aws-sdk/util-user-agent-browser": "3.212.0",
+                "@aws-sdk/util-user-agent-node": "3.212.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/client-sso-oidc": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.212.0.tgz",
+            "integrity": "sha512-Co0AU+y9KEAZUraT36ttFZlmwARsr82q2nQji5E8zg3zlUHtqGvMJqxArudz3iOb2E9WRi75MwAQmLO2xEk45A==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/fetch-http-handler": "3.212.0",
+                "@aws-sdk/hash-node": "3.212.0",
+                "@aws-sdk/invalid-dependency": "3.212.0",
+                "@aws-sdk/middleware-content-length": "3.212.0",
+                "@aws-sdk/middleware-endpoint": "3.212.0",
+                "@aws-sdk/middleware-host-header": "3.212.0",
+                "@aws-sdk/middleware-logger": "3.212.0",
+                "@aws-sdk/middleware-recursion-detection": "3.212.0",
+                "@aws-sdk/middleware-retry": "3.212.0",
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/middleware-user-agent": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/node-http-handler": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/smithy-client": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+                "@aws-sdk/util-defaults-mode-node": "3.212.0",
+                "@aws-sdk/util-endpoints": "3.212.0",
+                "@aws-sdk/util-user-agent-browser": "3.212.0",
+                "@aws-sdk/util-user-agent-node": "3.212.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/client-sts": {
+            "version": "3.213.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.213.0.tgz",
+            "integrity": "sha512-MCjtLaYVQJLIMeLubDc4yRjSyVVTOebKxhY4ix4cfpSA6X4jMc4gRY2eu4eja3qoISfHq/Ikrkxx9DD1+n1azg==",
+            "requires": {
+                "@aws-crypto/sha256-browser": "2.0.0",
+                "@aws-crypto/sha256-js": "2.0.0",
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/credential-provider-node": "3.212.0",
+                "@aws-sdk/fetch-http-handler": "3.212.0",
+                "@aws-sdk/hash-node": "3.212.0",
+                "@aws-sdk/invalid-dependency": "3.212.0",
+                "@aws-sdk/middleware-content-length": "3.212.0",
+                "@aws-sdk/middleware-endpoint": "3.212.0",
+                "@aws-sdk/middleware-host-header": "3.212.0",
+                "@aws-sdk/middleware-logger": "3.212.0",
+                "@aws-sdk/middleware-recursion-detection": "3.212.0",
+                "@aws-sdk/middleware-retry": "3.212.0",
+                "@aws-sdk/middleware-sdk-sts": "3.212.0",
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/middleware-signing": "3.212.0",
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/middleware-user-agent": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/node-http-handler": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/smithy-client": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "@aws-sdk/util-body-length-browser": "3.188.0",
+                "@aws-sdk/util-body-length-node": "3.208.0",
+                "@aws-sdk/util-defaults-mode-browser": "3.212.0",
+                "@aws-sdk/util-defaults-mode-node": "3.212.0",
+                "@aws-sdk/util-endpoints": "3.212.0",
+                "@aws-sdk/util-user-agent-browser": "3.212.0",
+                "@aws-sdk/util-user-agent-node": "3.212.0",
+                "@aws-sdk/util-utf8-browser": "3.188.0",
+                "@aws-sdk/util-utf8-node": "3.208.0",
+                "fast-xml-parser": "4.0.11",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/config-resolver": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.212.0.tgz",
+            "integrity": "sha512-hIP/Izpv6GCsDTnHCd/X9Ro7Mw5le+gr2VbkZHWR0c8+3xZWp8N5S0QnUBogF3Dv2KwPbmHP+bs/vqqo3miUjQ==",
+            "requires": {
+                "@aws-sdk/signature-v4": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-env": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.212.0.tgz",
+            "integrity": "sha512-HNYoqetLqTxwl0Grl4ez8Dx3I3hJfskxH2PTHYI1/iAqrY/gSB2oBOusvBeksbYrScnQM2IGqEcMJ4lzGLOH+w==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-imds": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.212.0.tgz",
+            "integrity": "sha512-Bg7cX2N5pJ//ft3Y8HWtpDSEMMgRTNMaNlIvTlDbAKYp7HBZRWSf9ZJnz2slT7qbyaJyRP5pSJC4XRm83g4leA==",
+            "requires": {
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-ini": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.212.0.tgz",
+            "integrity": "sha512-H7qRIP8qV7tRrCSJx2p5oQVMJASQWZUmi4l699hDMejmCO/m4pUMQFmWn2FXtZv8gTfzlkmp3wMixD5jnfL7pw==",
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.212.0",
+                "@aws-sdk/credential-provider-imds": "3.212.0",
+                "@aws-sdk/credential-provider-sso": "3.212.0",
+                "@aws-sdk/credential-provider-web-identity": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-node": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.212.0.tgz",
+            "integrity": "sha512-T44hoU3GCYHS+4GDVs7S/v2bBHmmYpnPayQsYXhDElQKXP0cFzQ78F8et4IU5lM94hwK+ISRQPrKaq4p77evkw==",
+            "requires": {
+                "@aws-sdk/credential-provider-env": "3.212.0",
+                "@aws-sdk/credential-provider-imds": "3.212.0",
+                "@aws-sdk/credential-provider-ini": "3.212.0",
+                "@aws-sdk/credential-provider-process": "3.212.0",
+                "@aws-sdk/credential-provider-sso": "3.212.0",
+                "@aws-sdk/credential-provider-web-identity": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-process": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.212.0.tgz",
+            "integrity": "sha512-bGaVKSm5Tf5VZtlM2V6k+M9nSKzlb14ldCcH0PGGMaK/dqnEJDVSxXPu3fWyomaxbLt7Is3AUMh6L2bq3kuXyA==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-sso": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.212.0.tgz",
+            "integrity": "sha512-OGatVUnWLp7PePs2H2RyYmTrwurl0tAfW+LWfVAPgYyvi2RQgTmSK5LJ3pXKxz3TvaSHkCvsT0NWNqdWY+iKWQ==",
+            "requires": {
+                "@aws-sdk/client-sso": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/token-providers": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.212.0.tgz",
+            "integrity": "sha512-zPF3KiVT14aeu4cRyEUelAJEAzFp++9ULLigQXhKBbFYaiOZMAHKRASO/WUK1ixYBC+ax4G1rbihLfQimXMtVA==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/endpoint-cache": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
+            "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
+            "requires": {
+                "mnemonist": "0.38.3",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/fetch-http-handler": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.212.0.tgz",
+            "integrity": "sha512-u7ehnpAVN8D0asWhyQitNVf1j5LdzCuxP/14Dx8+PvrUdZxQNVq2FVB+tkQvOs9pDHE/oROjVo7GNO42bmkitA==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/querystring-builder": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-base64": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/hash-node": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.212.0.tgz",
+            "integrity": "sha512-pwZkz83EvXHGURBYjBYS7Cr+gSr6pi23RDlP/aXREjJGs9QUQyixBh78oX5a3p6bB8JeizPcZS1dXKJ9OKCHAw==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/invalid-dependency": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.212.0.tgz",
+            "integrity": "sha512-zKVx+4Silmsr5Nvv9aGL5FmuHvdP9Dcvy/22fmWa3RRvCSNRpvFDeXtcDB5FvNpbWbO+qJyGj/OeqB/XejV13w==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/is-array-buffer": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+            "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-content-length": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.212.0.tgz",
+            "integrity": "sha512-gR6jeKGYNYqNLFRcuX3vv5PN1POLlB/9LDVYl3k/NNaCg8L1EKqqEtG84Gmn1AXH+2s6zMNs+gt5ygeqZQe2Cw==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-endpoint": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.212.0.tgz",
+            "integrity": "sha512-6ntKYehjxLun8hPXIPHSI2pGr/pHuQ6jcyO5wBq1kydSIIGiESl8H84DEt+yRvroCiYgbU+I8cACnRE0uv0bLA==",
+            "requires": {
+                "@aws-sdk/middleware-serde": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/signature-v4": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/url-parser": "3.212.0",
+                "@aws-sdk/util-config-provider": "3.208.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-endpoint-discovery": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.212.0.tgz",
+            "integrity": "sha512-CviyDda9MFM70v0hVQ8Ns6CJrOfOQQe+h0C/f8C4nzj31TmojJFRxnS0MmonZQcHPpyWH2Zt48RQhA9mui+ROQ==",
+            "requires": {
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/endpoint-cache": "3.208.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-host-header": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.212.0.tgz",
+            "integrity": "sha512-W00mxzK2OXy91Ncxri3cZJIxxSBzE72bX8FDa3xgC0ujbj49lw+rol6aV/Fw8Nda3CZ5xxulvJ4sXHt2eOtXSA==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-logger": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.212.0.tgz",
+            "integrity": "sha512-BSQqzKp4abf2wXvJEstB0zdr68yJMZXA14h53eSvtzykZLfvvFixR1nyVgKq+PKm1VaJ2fuZr10tjWRVQg1pYA==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-recursion-detection": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.212.0.tgz",
+            "integrity": "sha512-ATHPNtnd7nlm0jRXvr/c2xbxcna5ZGXEWTM5tUjIflOK9Rl3PCRce/hoQnHs45kv4l3daC53sPuRvTQ8O7K67A==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-retry": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.212.0.tgz",
+            "integrity": "sha512-lIi/JkYXalY6CYw2dJbQ/Xo64Ah3wfJ63BMTFQHQk1htnIDBnLd9a6ng96JgXJQMSO4ZEqRW/709NBlC157hbw==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/service-error-classification": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "tslib": "^2.3.1",
+                "uuid": "^8.3.2"
+            }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.212.0.tgz",
+            "integrity": "sha512-IcMfno3RJEXXS1Ch5lY0hgdSkGn9XW9m3XoKu1DjhEqR34ENDzvUmEN2PimIcZnz+9W59CU9UAMs/amRhwhlmw==",
+            "requires": {
+                "@aws-sdk/middleware-signing": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/signature-v4": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-serde": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.212.0.tgz",
+            "integrity": "sha512-KwRpwi/8vNDV0l8uvu1DPk0q3WR2pnp9VtUNZ6u9zU54hvVL+Z1PtQh/WfzJzNvtCHvtc/gVMs3Daqb/Ecrm5Q==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-signing": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.212.0.tgz",
+            "integrity": "sha512-pth95aEsxqQO0lrRAHZNVI5hrMtA14nEUPFjiLaXtOssZrjD6mBzXPRy1nKob6XWXOp/Vy0mnyI/FT/NnMflFw==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/signature-v4": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-stack": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.212.0.tgz",
+            "integrity": "sha512-AZ5f9ChioHsxGUojlzqI57sYyM9oW9SN/7AuiNafXU02j9jw7DKiYRn43lRUhgYnb/REhedHA5SsqIBF5eut/w==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/middleware-user-agent": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.212.0.tgz",
+            "integrity": "sha512-CVSY2kt+RaP6CVqSKp+1sPUAQFusTLZLFHVK0YPFzcIySJMqJC0l0/BzLhaIf5Bs3JHa/VGym8oDpp881yimHA==",
+            "requires": {
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/node-config-provider": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.212.0.tgz",
+            "integrity": "sha512-8AfOEDPe/D9DccUgredYg07GH2jrw07FCTyA1Pug5Hgbas7w14zbhLyQB0l6gcOJEuh34e/7oV9hN3s1hctnJg==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/node-http-handler": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.212.0.tgz",
+            "integrity": "sha512-wt4jK8HeYMjuQbWB4+Xt/nGyTvIwtLhm0SHcRgcoTsUjEiaPio/xNanyBWhPSUM87jpyG6bQMCzUtDbPeLqhkA==",
+            "requires": {
+                "@aws-sdk/abort-controller": "3.212.0",
+                "@aws-sdk/protocol-http": "3.212.0",
+                "@aws-sdk/querystring-builder": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/property-provider": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.212.0.tgz",
+            "integrity": "sha512-NMCIABfw3VZ7Vtn6iSeZRuSToRLxIHq0eGoUgO7T4fUp3U5vqYt28A5UY65KB9ifUPpNSllEG3EhEqs5qFw5+w==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/protocol-http": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.212.0.tgz",
+            "integrity": "sha512-EhkLPQC2TeqC3RGKfW87zoKj/gsWS4JJlRl5U6KMXejBMKQPzuopUiF9gQJ2iuou9BT8B+RsG2qgSHzrxp6lKw==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/querystring-builder": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.212.0.tgz",
+            "integrity": "sha512-4CaQstj0Aki3vc96Z0d481raNagmy9gnJtIv6yveATJ/57lk/RUv2WtTUOzpFKv/oNx5khix2tpbRqK9nCUxVg==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/querystring-parser": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.212.0.tgz",
+            "integrity": "sha512-ttarfAHMOYKgFHeBdgXID9SlNS7erH4gavN3fvf5R1RliCytUnzsTTvqa7CmVBFy0Xc/2yA+/6FFDKlOsS8tRg==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/service-error-classification": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.212.0.tgz",
+            "integrity": "sha512-jCv+uuFq4yGjP8FoCmoOGqnKNHHREDOFf7OxVSCluGMg2LXHfGxxqkqNFJlT3p+QdEp323GSWFY+PUsMJy7BLQ=="
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.212.0.tgz",
+            "integrity": "sha512-wKWqCA1oU57V//D3uAjQKGGj6rm6YKH4pWIU38Ypb/xNafiB7C51KtwpQVsS2HCNfmGrD03sGLKEZCSy9jvIlA==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/signature-v4": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.212.0.tgz",
+            "integrity": "sha512-tCrzWA60AWGDRmY9OyUrG0BzD+dDbAtHSqcY2LchGHOlMmv501/WXBIvn9fDfKp8GJj6Lb3VcG9cY1jCuKKcmg==",
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "@aws-sdk/types": "3.212.0",
+                "@aws-sdk/util-hex-encoding": "3.201.0",
+                "@aws-sdk/util-middleware": "3.212.0",
+                "@aws-sdk/util-uri-escape": "3.201.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/smithy-client": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.212.0.tgz",
+            "integrity": "sha512-dQUlM/eltp9JVEVQWGxU/6Or8jGQWK5mgmbP+BUHkfDgoMIeOFksIYon211KhE18EjoGgav1mr4/HHlcnekI2w==",
+            "requires": {
+                "@aws-sdk/middleware-stack": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/token-providers": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.212.0.tgz",
+            "integrity": "sha512-pTe4PM14b58nbfvIP9B0zW5dUIxEb/ALVzSLuxpJwJRI51E5QZmXJMT3P77MUd6niqKw0cRrnEHIgznD67JHSg==",
+            "requires": {
+                "@aws-sdk/client-sso-oidc": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/shared-ini-file-loader": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/types": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz",
+            "integrity": "sha512-uXBXB1PBYxfPyIvgmjbGdYBlS7rdeMG58uCaY3Ga5scY2xQnj7HU7knATKuIKk2DH1lLT0inqtsRVJS25zRK5w=="
+        },
+        "@aws-sdk/url-parser": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.212.0.tgz",
+            "integrity": "sha512-mTUQQRcVYqur7aHDuDMDKxN7Yr/5kIZB1RtMjIwtimTcf7TZaskN6sLTPo42YgASM6XQQhJECZaOE7Ow16i6Mg==",
+            "requires": {
+                "@aws-sdk/querystring-parser": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-base64": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+            "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+            "requires": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-body-length-browser": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+            "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-body-length-node": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+            "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-buffer-from": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+            "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+            "requires": {
+                "@aws-sdk/is-array-buffer": "3.201.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-config-provider": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+            "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.212.0.tgz",
+            "integrity": "sha512-tAs9+/lTtil545kyCqy7qjnnCq4S2S+4kBhHXgwRNPT85Nx5XCEEheWH6VZ45YufRaiRNFfX0n+odDwzDaev6g==",
+            "requires": {
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.212.0.tgz",
+            "integrity": "sha512-fNl1IDqn1mAoiM2Xv5KGAczXHy2+tPlouunIEePnQKTq0pzT3WqR13qleTfu1EcEz1oyGnDRoK91aP61Jxh3OQ==",
+            "requires": {
+                "@aws-sdk/config-resolver": "3.212.0",
+                "@aws-sdk/credential-provider-imds": "3.212.0",
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/property-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-dynamodb": {
+            "version": "3.214.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.214.0.tgz",
+            "integrity": "sha512-IsBJkNsMRwb8mtr8QYSXXPud0WG1pUD8hCBilWpxTat4Yr23aANhJX8ti1S4ks/iWU7AYjq/aSkSXH3cEkoVLA==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-endpoints": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.212.0.tgz",
+            "integrity": "sha512-/ADfvrZwhzUphre3pliO290IFOflvHyBBEaKn9WfRQ5veZxl+CuOEjxkwTJfHUrfWbh+xpCuOewWVLCptmoC4A==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-hex-encoding": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+            "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-locate-window": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-middleware": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.212.0.tgz",
+            "integrity": "sha512-621glUpwVKJRB8QxRG/5cAKIq8LKPdl/l8CS7vDg34f6j9BJmP5YVPcTzzQ6iskQAblkndiBAnSjp7kGujxuGg==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-uri-escape": {
+            "version": "3.201.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+            "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.212.0.tgz",
+            "integrity": "sha512-xXz16ge9NdKCwlD+952rfvgHdDe+pbCavbVMNdR60joHq5KYGR1e02l0LRNVe48/C9dAo2ezeJ+YnTPaw3Yl8Q==",
+            "requires": {
+                "@aws-sdk/types": "3.212.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-user-agent-node": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.212.0.tgz",
+            "integrity": "sha512-HE8VwtMtTXGkwUjryNpy+qyg7wrQxCGplDP59yo0YVn86B5f9nhRi/2jRAsKo9yf94iP7PXAz65TY9+KJC8UIg==",
+            "requires": {
+                "@aws-sdk/node-config-provider": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-utf8-browser": {
+            "version": "3.188.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+            "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+            "requires": {
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-utf8-node": {
+            "version": "3.208.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+            "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+            "requires": {
+                "@aws-sdk/util-buffer-from": "3.208.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@aws-sdk/util-waiter": {
+            "version": "3.212.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.212.0.tgz",
+            "integrity": "sha512-TsmNpXpefq414PrHWKO35e5YFGB/MyQBZ6Ia8+hs6wZgd7rrUFghC4yjn8eCRpnfpdegEsWGcQZ/qeyMafgvcg==",
+            "requires": {
+                "@aws-sdk/abort-controller": "3.212.0",
+                "@aws-sdk/types": "3.212.0",
+                "tslib": "^2.3.1"
+            }
+        },
+        "@esbuild/android-arm": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.14.tgz",
+            "integrity": "sha512-+Rb20XXxRGisNu2WmNKk+scpanb7nL5yhuI1KR9wQFiC43ddPj/V1fmNyzlFC9bKiG4mYzxW7egtoHVcynr+OA==",
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.14.tgz",
+            "integrity": "sha512-eQi9rosGNVQFJyJWV0HCA5WZae/qWIQME7s8/j8DMvnylfBv62Pbu+zJ2eUDqNf2O4u3WB+OEXyfkpBoe194sg==",
+            "optional": true
+        },
+        "bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+        },
+        "esbuild": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.14.tgz",
+            "integrity": "sha512-pJN8j42fvWLFWwSMG4luuupl2Me7mxciUOsMegKvwCmhEbJ2covUdFnihxm0FMIBV+cbwbtMoHgMCCI+pj1btQ==",
+            "requires": {
+                "@esbuild/android-arm": "0.15.14",
+                "@esbuild/linux-loong64": "0.15.14",
+                "esbuild-android-64": "0.15.14",
+                "esbuild-android-arm64": "0.15.14",
+                "esbuild-darwin-64": "0.15.14",
+                "esbuild-darwin-arm64": "0.15.14",
+                "esbuild-freebsd-64": "0.15.14",
+                "esbuild-freebsd-arm64": "0.15.14",
+                "esbuild-linux-32": "0.15.14",
+                "esbuild-linux-64": "0.15.14",
+                "esbuild-linux-arm": "0.15.14",
+                "esbuild-linux-arm64": "0.15.14",
+                "esbuild-linux-mips64le": "0.15.14",
+                "esbuild-linux-ppc64le": "0.15.14",
+                "esbuild-linux-riscv64": "0.15.14",
+                "esbuild-linux-s390x": "0.15.14",
+                "esbuild-netbsd-64": "0.15.14",
+                "esbuild-openbsd-64": "0.15.14",
+                "esbuild-sunos-64": "0.15.14",
+                "esbuild-windows-32": "0.15.14",
+                "esbuild-windows-64": "0.15.14",
+                "esbuild-windows-arm64": "0.15.14"
+            }
+        },
+        "esbuild-android-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.14.tgz",
+            "integrity": "sha512-HuilVIb4rk9abT4U6bcFdU35UHOzcWVGLSjEmC58OVr96q5UiRqzDtWjPlCMugjhgUGKEs8Zf4ueIvYbOStbIg==",
+            "optional": true
+        },
+        "esbuild-android-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.14.tgz",
+            "integrity": "sha512-/QnxRVxsR2Vtf3XottAHj7hENAMW2wCs6S+OZcAbc/8nlhbAL/bCQRCVD78VtI5mdwqWkVi3wMqM94kScQCgqg==",
+            "optional": true
+        },
+        "esbuild-darwin-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.14.tgz",
+            "integrity": "sha512-ToNuf1uifu8hhwWvoZJGCdLIX/1zpo8cOGnT0XAhDQXiKOKYaotVNx7pOVB1f+wHoWwTLInrOmh3EmA7Fd+8Vg==",
+            "optional": true
+        },
+        "esbuild-darwin-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.14.tgz",
+            "integrity": "sha512-KgGP+y77GszfYJgceO0Wi/PiRtYo5y2Xo9rhBUpxTPaBgWDJ14gqYN0+NMbu+qC2fykxXaipHxN4Scaj9tUS1A==",
+            "optional": true
+        },
+        "esbuild-freebsd-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.14.tgz",
+            "integrity": "sha512-xr0E2n5lyWw3uFSwwUXHc0EcaBDtsal/iIfLioflHdhAe10KSctV978Te7YsfnsMKzcoGeS366+tqbCXdqDHQA==",
+            "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.14.tgz",
+            "integrity": "sha512-8XH96sOQ4b1LhMlO10eEWOjEngmZ2oyw3pW4o8kvBcpF6pULr56eeYVP5radtgw54g3T8nKHDHYEI5AItvskZg==",
+            "optional": true
+        },
+        "esbuild-linux-32": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.14.tgz",
+            "integrity": "sha512-6ssnvwaTAi8AzKN8By2V0nS+WF5jTP7SfuK6sStGnDP7MCJo/4zHgM9oE1eQTS2jPmo3D673rckuCzRlig+HMA==",
+            "optional": true
+        },
+        "esbuild-linux-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.14.tgz",
+            "integrity": "sha512-ONySx3U0wAJOJuxGUlXBWxVKFVpWv88JEv0NZ6NlHknmDd1yCbf4AEdClSgLrqKQDXYywmw4gYDvdLsS6z0hcw==",
+            "optional": true
+        },
+        "esbuild-linux-arm": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.14.tgz",
+            "integrity": "sha512-D2LImAIV3QzL7lHURyCHBkycVFbKwkDb1XEUWan+2fb4qfW7qAeUtul7ZIcIwFKZgPcl+6gKZmvLgPSj26RQ2Q==",
+            "optional": true
+        },
+        "esbuild-linux-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.14.tgz",
+            "integrity": "sha512-kle2Ov6a1e5AjlHlMQl1e+c4myGTeggrRzArQFmWp6O6JoqqB9hT+B28EW4tjFWgV/NxUq46pWYpgaWXsXRPAg==",
+            "optional": true
+        },
+        "esbuild-linux-mips64le": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.14.tgz",
+            "integrity": "sha512-FVdMYIzOLXUq+OE7XYKesuEAqZhmAIV6qOoYahvUp93oXy0MOVTP370ECbPfGXXUdlvc0TNgkJa3YhEwyZ6MRA==",
+            "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.14.tgz",
+            "integrity": "sha512-2NzH+iuzMDA+jjtPjuIz/OhRDf8tzbQ1tRZJI//aT25o1HKc0reMMXxKIYq/8nSHXiJSnYV4ODzTiv45s+h73w==",
+            "optional": true
+        },
+        "esbuild-linux-riscv64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.14.tgz",
+            "integrity": "sha512-VqxvutZNlQxmUNS7Ac+aczttLEoHBJ9e3OYGqnULrfipRvG97qLrAv9EUY9iSrRKBqeEbSvS9bSfstZqwz0T4Q==",
+            "optional": true
+        },
+        "esbuild-linux-s390x": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.14.tgz",
+            "integrity": "sha512-+KVHEUshX5n6VP6Vp/AKv9fZIl5kr2ph8EUFmQUJnDpHwcfTSn2AQgYYm0HTBR2Mr4d0Wlr0FxF/Cs5pbFgiOw==",
+            "optional": true
+        },
+        "esbuild-netbsd-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.14.tgz",
+            "integrity": "sha512-6D/dr17piEgevIm1xJfZP2SjB9Z+g8ERhNnBdlZPBWZl+KSPUKLGF13AbvC+nzGh8IxOH2TyTIdRMvKMP0nEzQ==",
+            "optional": true
+        },
+        "esbuild-openbsd-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.14.tgz",
+            "integrity": "sha512-rREQBIlMibBetgr2E9Lywt2Qxv2ZdpmYahR4IUlAQ1Efv/A5gYdO0/VIN3iowDbCNTLxp0bb57Vf0LFcffD6kA==",
+            "optional": true
+        },
+        "esbuild-sunos-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.14.tgz",
+            "integrity": "sha512-DNVjSp/BY4IfwtdUAvWGIDaIjJXY5KI4uD82+15v6k/w7px9dnaDaJJ2R6Mu+KCgr5oklmFc0KjBjh311Gxl9Q==",
+            "optional": true
+        },
+        "esbuild-windows-32": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.14.tgz",
+            "integrity": "sha512-pHBWrcA+/oLgvViuG9FO3kNPO635gkoVrRQwe6ZY1S0jdET07xe2toUvQoJQ8KT3/OkxqUasIty5hpuKFLD+eg==",
+            "optional": true
+        },
+        "esbuild-windows-64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.14.tgz",
+            "integrity": "sha512-CszIGQVk/P8FOS5UgAH4hKc9zOaFo69fe+k1rqgBHx3CSK3Opyk5lwYriIamaWOVjBt7IwEP6NALz+tkVWdFog==",
+            "optional": true
+        },
+        "esbuild-windows-arm64": {
+            "version": "0.15.14",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.14.tgz",
+            "integrity": "sha512-KW9W4psdZceaS9A7Jsgl4WialOznSURvqX/oHZk3gOP7KbjtHLSsnmSvNdzagGJfxbAe30UVGXRe8q8nDsOSQw==",
+            "optional": true
+        },
+        "fast-xml-parser": {
+            "version": "4.0.11",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+            "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+            "requires": {
+                "strnum": "^1.0.5"
+            }
+        },
+        "mnemonist": {
+            "version": "0.38.3",
+            "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+            "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+            "requires": {
+                "obliterator": "^1.6.1"
+            }
+        },
+        "obliterator": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+            "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
+        },
+        "strnum": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
+        },
+        "tslib": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+        },
+        "uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+    }
+}

--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "hello-world-function",
+    "dependencies": {
+        "@aws-sdk/client-dynamodb": "^3.211.0",
+        "@aws-sdk/util-dynamodb": "^3.214.0",
+        "esbuild": "^0.15.14"
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,6 @@
         "": {
             "name": "delete-test-01",
             "version": "0.0.1",
-            "dependencies": {
-                "@aws-sdk/client-dynamodb": "^3.211.0"
-            },
             "devDependencies": {
                 "jest": "^26.6.3"
             }
@@ -27,985 +24,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@aws-crypto/ie11-detection": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-crypto/sha256-browser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-            "dependencies": {
-                "@aws-crypto/ie11-detection": "^2.0.0",
-                "@aws-crypto/sha256-js": "^2.0.0",
-                "@aws-crypto/supports-web-crypto": "^2.0.0",
-                "@aws-crypto/util": "^2.0.0",
-                "@aws-sdk/types": "^3.1.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-crypto/sha256-js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-            "dependencies": {
-                "@aws-crypto/util": "^2.0.0",
-                "@aws-sdk/types": "^3.1.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-crypto/util": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-            "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-            "dependencies": {
-                "@aws-sdk/types": "^3.110.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/util/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        },
-        "node_modules/@aws-sdk/abort-controller": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-            "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-dynamodb": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.211.0.tgz",
-            "integrity": "sha512-SoinZ+k1TgY/99dUZ2S+FH+sXG3+BaFaSd98if0dygTqIftq9ctaRbDQFss64hdrqu6Qpuvak4XhqaRMaQOr2A==",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.211.0",
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/credential-provider-node": "3.211.0",
-                "@aws-sdk/fetch-http-handler": "3.208.0",
-                "@aws-sdk/hash-node": "3.208.0",
-                "@aws-sdk/invalid-dependency": "3.208.0",
-                "@aws-sdk/middleware-content-length": "3.208.0",
-                "@aws-sdk/middleware-endpoint": "3.208.0",
-                "@aws-sdk/middleware-endpoint-discovery": "3.209.0",
-                "@aws-sdk/middleware-host-header": "3.208.0",
-                "@aws-sdk/middleware-logger": "3.208.0",
-                "@aws-sdk/middleware-recursion-detection": "3.208.0",
-                "@aws-sdk/middleware-retry": "3.209.0",
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/middleware-signing": "3.208.0",
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/middleware-user-agent": "3.208.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/node-http-handler": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/smithy-client": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "@aws-sdk/util-body-length-browser": "3.188.0",
-                "@aws-sdk/util-body-length-node": "3.208.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-                "@aws-sdk/util-defaults-mode-node": "3.209.0",
-                "@aws-sdk/util-endpoints": "3.211.0",
-                "@aws-sdk/util-user-agent-browser": "3.208.0",
-                "@aws-sdk/util-user-agent-node": "3.209.0",
-                "@aws-sdk/util-utf8-browser": "3.188.0",
-                "@aws-sdk/util-utf8-node": "3.208.0",
-                "@aws-sdk/util-waiter": "3.208.0",
-                "tslib": "^2.3.1",
-                "uuid": "^8.3.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
-            "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/fetch-http-handler": "3.208.0",
-                "@aws-sdk/hash-node": "3.208.0",
-                "@aws-sdk/invalid-dependency": "3.208.0",
-                "@aws-sdk/middleware-content-length": "3.208.0",
-                "@aws-sdk/middleware-endpoint": "3.208.0",
-                "@aws-sdk/middleware-host-header": "3.208.0",
-                "@aws-sdk/middleware-logger": "3.208.0",
-                "@aws-sdk/middleware-recursion-detection": "3.208.0",
-                "@aws-sdk/middleware-retry": "3.209.0",
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/middleware-user-agent": "3.208.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/node-http-handler": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/smithy-client": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "@aws-sdk/util-body-length-browser": "3.188.0",
-                "@aws-sdk/util-body-length-node": "3.208.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-                "@aws-sdk/util-defaults-mode-node": "3.209.0",
-                "@aws-sdk/util-endpoints": "3.211.0",
-                "@aws-sdk/util-user-agent-browser": "3.208.0",
-                "@aws-sdk/util-user-agent-node": "3.209.0",
-                "@aws-sdk/util-utf8-browser": "3.188.0",
-                "@aws-sdk/util-utf8-node": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sso-oidc": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
-            "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/fetch-http-handler": "3.208.0",
-                "@aws-sdk/hash-node": "3.208.0",
-                "@aws-sdk/invalid-dependency": "3.208.0",
-                "@aws-sdk/middleware-content-length": "3.208.0",
-                "@aws-sdk/middleware-endpoint": "3.208.0",
-                "@aws-sdk/middleware-host-header": "3.208.0",
-                "@aws-sdk/middleware-logger": "3.208.0",
-                "@aws-sdk/middleware-recursion-detection": "3.208.0",
-                "@aws-sdk/middleware-retry": "3.209.0",
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/middleware-user-agent": "3.208.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/node-http-handler": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/smithy-client": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "@aws-sdk/util-body-length-browser": "3.188.0",
-                "@aws-sdk/util-body-length-node": "3.208.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-                "@aws-sdk/util-defaults-mode-node": "3.209.0",
-                "@aws-sdk/util-endpoints": "3.211.0",
-                "@aws-sdk/util-user-agent-browser": "3.208.0",
-                "@aws-sdk/util-user-agent-node": "3.209.0",
-                "@aws-sdk/util-utf8-browser": "3.188.0",
-                "@aws-sdk/util-utf8-node": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/client-sts": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
-            "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/credential-provider-node": "3.211.0",
-                "@aws-sdk/fetch-http-handler": "3.208.0",
-                "@aws-sdk/hash-node": "3.208.0",
-                "@aws-sdk/invalid-dependency": "3.208.0",
-                "@aws-sdk/middleware-content-length": "3.208.0",
-                "@aws-sdk/middleware-endpoint": "3.208.0",
-                "@aws-sdk/middleware-host-header": "3.208.0",
-                "@aws-sdk/middleware-logger": "3.208.0",
-                "@aws-sdk/middleware-recursion-detection": "3.208.0",
-                "@aws-sdk/middleware-retry": "3.209.0",
-                "@aws-sdk/middleware-sdk-sts": "3.208.0",
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/middleware-signing": "3.208.0",
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/middleware-user-agent": "3.208.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/node-http-handler": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/smithy-client": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "@aws-sdk/util-body-length-browser": "3.188.0",
-                "@aws-sdk/util-body-length-node": "3.208.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-                "@aws-sdk/util-defaults-mode-node": "3.209.0",
-                "@aws-sdk/util-endpoints": "3.211.0",
-                "@aws-sdk/util-user-agent-browser": "3.208.0",
-                "@aws-sdk/util-user-agent-node": "3.209.0",
-                "@aws-sdk/util-utf8-browser": "3.188.0",
-                "@aws-sdk/util-utf8-node": "3.208.0",
-                "fast-xml-parser": "4.0.11",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/config-resolver": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-            "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-            "dependencies": {
-                "@aws-sdk/signature-v4": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-config-provider": "3.208.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-            "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-imds": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-            "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-            "dependencies": {
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
-            "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.208.0",
-                "@aws-sdk/credential-provider-imds": "3.209.0",
-                "@aws-sdk/credential-provider-sso": "3.211.0",
-                "@aws-sdk/credential-provider-web-identity": "3.208.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
-            "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
-            "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.208.0",
-                "@aws-sdk/credential-provider-imds": "3.209.0",
-                "@aws-sdk/credential-provider-ini": "3.211.0",
-                "@aws-sdk/credential-provider-process": "3.209.0",
-                "@aws-sdk/credential-provider-sso": "3.211.0",
-                "@aws-sdk/credential-provider-web-identity": "3.208.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
-            "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
-            "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
-            "dependencies": {
-                "@aws-sdk/client-sso": "3.211.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/token-providers": "3.211.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-            "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/endpoint-cache": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
-            "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
-            "dependencies": {
-                "mnemonist": "0.38.3",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/fetch-http-handler": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-            "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/querystring-builder": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-sdk/hash-node": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-            "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-buffer-from": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/invalid-dependency": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-            "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-sdk/is-array-buffer": {
-            "version": "3.201.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-            "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-content-length": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-            "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-endpoint": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.208.0.tgz",
-            "integrity": "sha512-pVa/cyB6ronfTVAoKUUTFbAPslDPU43DWOKXY/bACC3ys1lFo1CWjz4dLSQARxEEW3iZ1yZTy0zoHXnNrw5CFQ==",
-            "dependencies": {
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/signature-v4": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-config-provider": "3.208.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.209.0.tgz",
-            "integrity": "sha512-ZBWYhTBfdc/bUNB1N4jL8ZW7NmKTkdowbZHTlxtXi8ySzzn+qlD+XosIEbXqrVR9sYxSVC3kwsQvADxHzKGixw==",
-            "dependencies": {
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/endpoint-cache": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-            "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-            "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.208.0.tgz",
-            "integrity": "sha512-Dgpf5NEOYXvkQuGcbxvDovTh4HwO4ULJReGko67NJjgdZZyFS1fNykVPncxenRpsN9SJBigswYs3lwPVpqijzA==",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-retry": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-            "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/service-error-classification": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "tslib": "^2.3.1",
-                "uuid": "^8.3.2"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-            "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
-            "dependencies": {
-                "@aws-sdk/middleware-signing": "3.208.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/signature-v4": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-serde": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-            "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-            "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/signature-v4": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-stack": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-            "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-            "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-            "dependencies": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/node-config-provider": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-            "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/node-http-handler": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-            "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-            "dependencies": {
-                "@aws-sdk/abort-controller": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/querystring-builder": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/property-provider": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-            "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/protocol-http": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-            "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/querystring-builder": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-            "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-uri-escape": "3.201.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/querystring-parser": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-            "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/service-error-classification": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-            "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw==",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/shared-ini-file-loader": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-            "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/signature-v4": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-            "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-            "dependencies": {
-                "@aws-sdk/is-array-buffer": "3.201.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-hex-encoding": "3.201.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "@aws-sdk/util-uri-escape": "3.201.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/smithy-client": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-            "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-            "dependencies": {
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/token-providers": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
-            "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
-            "dependencies": {
-                "@aws-sdk/client-sso-oidc": "3.211.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/types": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-            "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw==",
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/url-parser": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-            "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-            "dependencies": {
-                "@aws-sdk/querystring-parser": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-sdk/util-base64": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-            "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-            "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-body-length-browser": {
-            "version": "3.188.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-            "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-sdk/util-body-length-node": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-            "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-buffer-from": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-            "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-            "dependencies": {
-                "@aws-sdk/is-array-buffer": "3.201.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-config-provider": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-            "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-            "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-            "dependencies": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-defaults-mode-node": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-            "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-            "dependencies": {
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/credential-provider-imds": "3.209.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">= 10.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
-            "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-hex-encoding": {
-            "version": "3.201.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-            "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-middleware": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.208.0.tgz",
-            "integrity": "sha512-oXilrYpXwaPyMw1uNjL1wmR54zeFzIWx2ve1MSMheIYr26deFP3RpMfKkGXwiOvXzZ9pzTcA8shNLhg1frO/zg==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-uri-escape": {
-            "version": "3.201.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-            "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-            "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-            "dependencies": {
-                "@aws-sdk/types": "3.208.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-            "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-            "dependencies": {
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "peerDependencies": {
-                "aws-crt": ">=1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "aws-crt": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.188.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-            "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-            "dependencies": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "node_modules/@aws-sdk/util-utf8-node": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-            "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-            "dependencies": {
-                "@aws-sdk/util-buffer-from": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/util-waiter": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
-            "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
-            "dependencies": {
-                "@aws-sdk/abort-controller": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
         "node_modules/@babel/code-frame": {
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -1019,30 +37,30 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
-            "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
+            "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
-            "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
+            "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.3",
-                "@babel/helper-compilation-targets": "^7.19.3",
-                "@babel/helper-module-transforms": "^7.19.0",
-                "@babel/helpers": "^7.19.0",
-                "@babel/parser": "^7.19.3",
+                "@babel/generator": "^7.20.2",
+                "@babel/helper-compilation-targets": "^7.20.0",
+                "@babel/helper-module-transforms": "^7.20.2",
+                "@babel/helpers": "^7.20.1",
+                "@babel/parser": "^7.20.2",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.3",
-                "@babel/types": "^7.19.3",
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -1058,12 +76,12 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.19.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.5.tgz",
-            "integrity": "sha512-DxbNz9Lz4aMZ99qPpO1raTbcrI1ZeYh+9NR9qhfkQIbFtVEqotHojEBxHzmxhVONkGt6VyrqVQcgpefMy9pqcg==",
+            "version": "7.20.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
+            "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.19.4",
+                "@babel/types": "^7.20.2",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             },
@@ -1086,12 +104,12 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-            "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+            "version": "7.20.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+            "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.19.3",
+                "@babel/compat-data": "^7.20.0",
                 "@babel/helper-validator-option": "^7.18.6",
                 "browserslist": "^4.21.3",
                 "semver": "^6.3.0"
@@ -1150,40 +168,40 @@
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
-            "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
+            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.18.6",
+                "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/helper-validator-identifier": "^7.18.6",
+                "@babel/helper-validator-identifier": "^7.19.1",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.0",
-                "@babel/types": "^7.19.0"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-            "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+            "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
-            "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+            "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.19.4"
+                "@babel/types": "^7.20.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1229,14 +247,14 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
-            "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
+            "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.4",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1328,9 +346,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
-            "integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==",
+            "version": "7.20.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
+            "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1501,19 +519,19 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.4.tgz",
-            "integrity": "sha512-w3K1i+V5u2aJUOXBFFC5pveFLmtq1s3qcdDNC2qRI6WPBQIDaKFqXxDEqDO/h1dQ3HjsZoZMyIy6jGLq0xtw+g==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
+            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.4",
+                "@babel/generator": "^7.20.1",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.4",
-                "@babel/types": "^7.19.4",
+                "@babel/parser": "^7.20.1",
+                "@babel/types": "^7.20.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -1522,9 +540,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
-            "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -1847,9 +865,9 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.16",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz",
-            "integrity": "sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==",
+            "version": "0.3.17",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "3.1.0",
@@ -1857,9 +875,9 @@
             }
         },
         "node_modules/@sinonjs/commons": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
+            "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
             "dev": true,
             "dependencies": {
                 "type-detect": "4.0.8"
@@ -1884,9 +902,9 @@
             }
         },
         "node_modules/@types/babel__core": {
-            "version": "7.1.19",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
-            "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
+            "version": "7.1.20",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.20.tgz",
+            "integrity": "sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==",
             "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.1.0",
@@ -1958,9 +976,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "18.8.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
-            "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
+            "version": "18.11.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
             "dev": true
         },
         "node_modules/@types/normalize-package-data": {
@@ -2003,9 +1021,9 @@
             "dev": true
         },
         "node_modules/acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -2325,11 +1343,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/bowser": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
-        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2440,9 +1453,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001419",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz",
-            "integrity": "sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==",
+            "version": "1.0.30001431",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+            "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
             "dev": true,
             "funding": [
                 {
@@ -2869,9 +1882,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.282",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.282.tgz",
-            "integrity": "sha512-Dki0WhHNh/br/Xi1vAkueU5mtIc9XLHcMKB6tNfQKk+kPG0TEUjRh5QEMAUbRp30/rYNMFD1zKKvbVzwq/4wmg==",
+            "version": "1.4.284",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -3249,21 +2262,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
-        },
-        "node_modules/fast-xml-parser": {
-            "version": "4.0.11",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-            "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-            "dependencies": {
-                "strnum": "^1.0.5"
-            },
-            "bin": {
-                "fxparser": "src/cli/cli.js"
-            },
-            "funding": {
-                "type": "paypal",
-                "url": "https://paypal.me/naturalintelligence"
-            }
         },
         "node_modules/fb-watchman": {
             "version": "2.0.2",
@@ -3690,9 +2688,9 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-            "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+            "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -4226,9 +3224,9 @@
             }
         },
         "node_modules/jest-pnp-resolver": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-            "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -4788,14 +3786,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/mnemonist": {
-            "version": "0.38.3",
-            "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
-            "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-            "dependencies": {
-                "obliterator": "^1.6.1"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5035,11 +4025,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/obliterator": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-            "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
         },
         "node_modules/once": {
             "version": "1.4.0",
@@ -6222,9 +5207,9 @@
             "dev": true
         },
         "node_modules/stack-utils": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-            "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
             "dev": true,
             "dependencies": {
                 "escape-string-regexp": "^2.0.0"
@@ -6394,11 +5379,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/strnum": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
@@ -6571,11 +5551,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
         },
         "node_modules/type-check": {
             "version": "0.3.2",
@@ -6756,6 +5731,8 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "optional": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -6797,6 +5774,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
             "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+            "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
             "dev": true,
             "dependencies": {
                 "browser-process-hrtime": "^1.0.0"
@@ -7015,825 +5993,6 @@
                 "@jridgewell/trace-mapping": "^0.3.9"
             }
         },
-        "@aws-crypto/ie11-detection": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-            "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-            "requires": {
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
-            }
-        },
-        "@aws-crypto/sha256-browser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-            "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-            "requires": {
-                "@aws-crypto/ie11-detection": "^2.0.0",
-                "@aws-crypto/sha256-js": "^2.0.0",
-                "@aws-crypto/supports-web-crypto": "^2.0.0",
-                "@aws-crypto/util": "^2.0.0",
-                "@aws-sdk/types": "^3.1.0",
-                "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
-            }
-        },
-        "@aws-crypto/sha256-js": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-            "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-            "requires": {
-                "@aws-crypto/util": "^2.0.0",
-                "@aws-sdk/types": "^3.1.0",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
-            }
-        },
-        "@aws-crypto/supports-web-crypto": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-            "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-            "requires": {
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
-            }
-        },
-        "@aws-crypto/util": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-            "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-            "requires": {
-                "@aws-sdk/types": "^3.110.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
-            }
-        },
-        "@aws-sdk/abort-controller": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.208.0.tgz",
-            "integrity": "sha512-mQkDR+8VLCafg9KI4TgftftBOL170ricyb+HgV8n5jLDrEG+TfOfud8e6us2lIFESEuMpohC+/8yIcf6JjKkMg==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/client-dynamodb": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.211.0.tgz",
-            "integrity": "sha512-SoinZ+k1TgY/99dUZ2S+FH+sXG3+BaFaSd98if0dygTqIftq9ctaRbDQFss64hdrqu6Qpuvak4XhqaRMaQOr2A==",
-            "requires": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/client-sts": "3.211.0",
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/credential-provider-node": "3.211.0",
-                "@aws-sdk/fetch-http-handler": "3.208.0",
-                "@aws-sdk/hash-node": "3.208.0",
-                "@aws-sdk/invalid-dependency": "3.208.0",
-                "@aws-sdk/middleware-content-length": "3.208.0",
-                "@aws-sdk/middleware-endpoint": "3.208.0",
-                "@aws-sdk/middleware-endpoint-discovery": "3.209.0",
-                "@aws-sdk/middleware-host-header": "3.208.0",
-                "@aws-sdk/middleware-logger": "3.208.0",
-                "@aws-sdk/middleware-recursion-detection": "3.208.0",
-                "@aws-sdk/middleware-retry": "3.209.0",
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/middleware-signing": "3.208.0",
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/middleware-user-agent": "3.208.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/node-http-handler": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/smithy-client": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "@aws-sdk/util-body-length-browser": "3.188.0",
-                "@aws-sdk/util-body-length-node": "3.208.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-                "@aws-sdk/util-defaults-mode-node": "3.209.0",
-                "@aws-sdk/util-endpoints": "3.211.0",
-                "@aws-sdk/util-user-agent-browser": "3.208.0",
-                "@aws-sdk/util-user-agent-node": "3.209.0",
-                "@aws-sdk/util-utf8-browser": "3.188.0",
-                "@aws-sdk/util-utf8-node": "3.208.0",
-                "@aws-sdk/util-waiter": "3.208.0",
-                "tslib": "^2.3.1",
-                "uuid": "^8.3.2"
-            }
-        },
-        "@aws-sdk/client-sso": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.211.0.tgz",
-            "integrity": "sha512-Wuo3ZYPy9L+OixlZ7/wM1BbPBdC22xO/a8z/J1sgQZiRDl80Ax+jf1u17D91xdZJGH0hTU5AlvEY7mHP0y/hAw==",
-            "requires": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/fetch-http-handler": "3.208.0",
-                "@aws-sdk/hash-node": "3.208.0",
-                "@aws-sdk/invalid-dependency": "3.208.0",
-                "@aws-sdk/middleware-content-length": "3.208.0",
-                "@aws-sdk/middleware-endpoint": "3.208.0",
-                "@aws-sdk/middleware-host-header": "3.208.0",
-                "@aws-sdk/middleware-logger": "3.208.0",
-                "@aws-sdk/middleware-recursion-detection": "3.208.0",
-                "@aws-sdk/middleware-retry": "3.209.0",
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/middleware-user-agent": "3.208.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/node-http-handler": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/smithy-client": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "@aws-sdk/util-body-length-browser": "3.188.0",
-                "@aws-sdk/util-body-length-node": "3.208.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-                "@aws-sdk/util-defaults-mode-node": "3.209.0",
-                "@aws-sdk/util-endpoints": "3.211.0",
-                "@aws-sdk/util-user-agent-browser": "3.208.0",
-                "@aws-sdk/util-user-agent-node": "3.209.0",
-                "@aws-sdk/util-utf8-browser": "3.188.0",
-                "@aws-sdk/util-utf8-node": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/client-sso-oidc": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.211.0.tgz",
-            "integrity": "sha512-oJ+5ROykVsXpBFpWUfSUYHz/RcTjsZPri6CIY+wQmEFDAOxTsgxd7l8VkqX1r/U/QiK/xDXuK+Z7MurywXS+rQ==",
-            "requires": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/fetch-http-handler": "3.208.0",
-                "@aws-sdk/hash-node": "3.208.0",
-                "@aws-sdk/invalid-dependency": "3.208.0",
-                "@aws-sdk/middleware-content-length": "3.208.0",
-                "@aws-sdk/middleware-endpoint": "3.208.0",
-                "@aws-sdk/middleware-host-header": "3.208.0",
-                "@aws-sdk/middleware-logger": "3.208.0",
-                "@aws-sdk/middleware-recursion-detection": "3.208.0",
-                "@aws-sdk/middleware-retry": "3.209.0",
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/middleware-user-agent": "3.208.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/node-http-handler": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/smithy-client": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "@aws-sdk/util-body-length-browser": "3.188.0",
-                "@aws-sdk/util-body-length-node": "3.208.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-                "@aws-sdk/util-defaults-mode-node": "3.209.0",
-                "@aws-sdk/util-endpoints": "3.211.0",
-                "@aws-sdk/util-user-agent-browser": "3.208.0",
-                "@aws-sdk/util-user-agent-node": "3.209.0",
-                "@aws-sdk/util-utf8-browser": "3.188.0",
-                "@aws-sdk/util-utf8-node": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/client-sts": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.211.0.tgz",
-            "integrity": "sha512-39/PMIKLEaRUztx3m4I0x9SCnqTStaQuqIabAK/wk0uy+O2p32sv7eacRrGjZWHngqdsK7S1s/LSFErYzzIvkw==",
-            "requires": {
-                "@aws-crypto/sha256-browser": "2.0.0",
-                "@aws-crypto/sha256-js": "2.0.0",
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/credential-provider-node": "3.211.0",
-                "@aws-sdk/fetch-http-handler": "3.208.0",
-                "@aws-sdk/hash-node": "3.208.0",
-                "@aws-sdk/invalid-dependency": "3.208.0",
-                "@aws-sdk/middleware-content-length": "3.208.0",
-                "@aws-sdk/middleware-endpoint": "3.208.0",
-                "@aws-sdk/middleware-host-header": "3.208.0",
-                "@aws-sdk/middleware-logger": "3.208.0",
-                "@aws-sdk/middleware-recursion-detection": "3.208.0",
-                "@aws-sdk/middleware-retry": "3.209.0",
-                "@aws-sdk/middleware-sdk-sts": "3.208.0",
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/middleware-signing": "3.208.0",
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/middleware-user-agent": "3.208.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/node-http-handler": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/smithy-client": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "@aws-sdk/util-body-length-browser": "3.188.0",
-                "@aws-sdk/util-body-length-node": "3.208.0",
-                "@aws-sdk/util-defaults-mode-browser": "3.209.0",
-                "@aws-sdk/util-defaults-mode-node": "3.209.0",
-                "@aws-sdk/util-endpoints": "3.211.0",
-                "@aws-sdk/util-user-agent-browser": "3.208.0",
-                "@aws-sdk/util-user-agent-node": "3.209.0",
-                "@aws-sdk/util-utf8-browser": "3.188.0",
-                "@aws-sdk/util-utf8-node": "3.208.0",
-                "fast-xml-parser": "4.0.11",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/config-resolver": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.209.0.tgz",
-            "integrity": "sha512-wLXI1Jg9xx9wE8vdIfOgSKnoBWbn9j3IvW4+7PnM/nf5xC30/Jp4j+JndEG/BKyDQF7HJQTIeRpSkwKaqJhCRA==",
-            "requires": {
-                "@aws-sdk/signature-v4": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-config-provider": "3.208.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/credential-provider-env": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.208.0.tgz",
-            "integrity": "sha512-FB+KUSpZc03wVTXxGnMmgtaP0sJOv0D7oyogHb7wcf5b7RjjwqoaeUcJHTdKRZaW6e1foLk3/L9uebxiWefDbQ==",
-            "requires": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/credential-provider-imds": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.209.0.tgz",
-            "integrity": "sha512-EjA1nWduIHjALjNF6O2lpKVOoTIlfGHgvqCxjFf7XNqBTTKWCxEflcmUgqXwo9A7TU0mTTyr7nLGMAsNE2CR3w==",
-            "requires": {
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/credential-provider-ini": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.211.0.tgz",
-            "integrity": "sha512-kFekBDGX3tMsbEBjpCHt2dp5hx7xBN0d7v+fNXky4fB61bNUxcLNpXkTgDIqRyMzEje3Jov9Be9Qgqb8ud0Fiw==",
-            "requires": {
-                "@aws-sdk/credential-provider-env": "3.208.0",
-                "@aws-sdk/credential-provider-imds": "3.209.0",
-                "@aws-sdk/credential-provider-sso": "3.211.0",
-                "@aws-sdk/credential-provider-web-identity": "3.208.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/credential-provider-node": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.211.0.tgz",
-            "integrity": "sha512-RWDitzHmZOfrfTZCnL8nOLQgYgawAAw8IF5pqeNjcN9TZ/pR64B9pusTYD7a+uVDB8kb9vMU767g89ts2pqmfQ==",
-            "requires": {
-                "@aws-sdk/credential-provider-env": "3.208.0",
-                "@aws-sdk/credential-provider-imds": "3.209.0",
-                "@aws-sdk/credential-provider-ini": "3.211.0",
-                "@aws-sdk/credential-provider-process": "3.209.0",
-                "@aws-sdk/credential-provider-sso": "3.211.0",
-                "@aws-sdk/credential-provider-web-identity": "3.208.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/credential-provider-process": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.209.0.tgz",
-            "integrity": "sha512-G0urC5p1kgUfgpK8lncdisSewa8onnoQAVdf2Uh51hOqc7UufGce+ouvLH8J2iMkMaL1MSyu8fqwfZNyDtH37g==",
-            "requires": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/credential-provider-sso": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.211.0.tgz",
-            "integrity": "sha512-S8ciHRypUCi0Uz0D80yVGkWmvpCBCvkEaj+IO0LdYX05GDnH/B44DA8UQ0pfAJqLy5BeSO5snKVRKSPzxNtUGw==",
-            "requires": {
-                "@aws-sdk/client-sso": "3.211.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/token-providers": "3.211.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.208.0.tgz",
-            "integrity": "sha512-7wtrdEr8uvDr5t0stimrXGsW4G+TQyluZ9OucCCY0HXgNihmnk1BIu+COuOSxRtFXHwCh4rIPaVE1ABG2Mq24g==",
-            "requires": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/endpoint-cache": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.208.0.tgz",
-            "integrity": "sha512-MkrCvaZhTb1qZCjcDH73t5n43h0Kr0GS+30lpXZ9PAnHJZPqv+vhWFPK0ZsFe1XktbS0WOoDR4ED+lWm0Dw7Rg==",
-            "requires": {
-                "mnemonist": "0.38.3",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/fetch-http-handler": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.208.0.tgz",
-            "integrity": "sha512-GuwkwOeyLKCbSbnFlyHdlKd7u54cnQUI8NfVDAxpZvomY3PV476Tzg8XEyOYE67r5rR6XMqn6IK1PmFAACY+ew==",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/querystring-builder": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-base64": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/hash-node": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.208.0.tgz",
-            "integrity": "sha512-X5u6nD9+wzaA6qhqbobxsIgiyDJMW8NgqjZgHoc5x1wz4unHUCEuSBZy1kbIZ6+EPZ9bQHQZ21gKgf1j5vhsvQ==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-buffer-from": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/invalid-dependency": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.208.0.tgz",
-            "integrity": "sha512-mUpbtijk14KntYy+w5FSvmsfj/Dqa8HylYeCKniKBKkQ1avjEz7CdizVoxyZrR3rldnLE3gItr0FEDRUhtfkAA==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/is-array-buffer": {
-            "version": "3.201.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
-            "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-content-length": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.208.0.tgz",
-            "integrity": "sha512-8bLh7lHtmKQQ2fk0fGiP7pcVJglB/dz7Q9OooxFYK+eybqxfIDDUgKphA8AFT5W34tJRh5nhT3QTJ6zrOTQM3w==",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-endpoint": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.208.0.tgz",
-            "integrity": "sha512-pVa/cyB6ronfTVAoKUUTFbAPslDPU43DWOKXY/bACC3ys1lFo1CWjz4dLSQARxEEW3iZ1yZTy0zoHXnNrw5CFQ==",
-            "requires": {
-                "@aws-sdk/middleware-serde": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/signature-v4": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/url-parser": "3.208.0",
-                "@aws-sdk/util-config-provider": "3.208.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-endpoint-discovery": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.209.0.tgz",
-            "integrity": "sha512-ZBWYhTBfdc/bUNB1N4jL8ZW7NmKTkdowbZHTlxtXi8ySzzn+qlD+XosIEbXqrVR9sYxSVC3kwsQvADxHzKGixw==",
-            "requires": {
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/endpoint-cache": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-host-header": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.208.0.tgz",
-            "integrity": "sha512-3oyXK81TLWOZ2T/9Ltpbj/Z7R4QWSf+FCQRpY48ND2im/ALkgFRk/tmDTOshv+TQzW1q2lOSEeq4vK6yOCar7g==",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-logger": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.208.0.tgz",
-            "integrity": "sha512-mwSpuWruB8RrgUAAW7w/lvadnMDesl/bZ2IELBgJri+2rIqLGbAtygJBiG0Y3e8/IeOHuKuGkN1rFYZ4SKr7/A==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.208.0.tgz",
-            "integrity": "sha512-Dgpf5NEOYXvkQuGcbxvDovTh4HwO4ULJReGko67NJjgdZZyFS1fNykVPncxenRpsN9SJBigswYs3lwPVpqijzA==",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-retry": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.209.0.tgz",
-            "integrity": "sha512-PGHbpGw74HxmtqsMEH+xn2oC5/BPdHVyapB66x83n+sywt1ejTiarbQhNs70YzcSsTrJfbhbrFP1V9AzRmMaQA==",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/service-error-classification": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "tslib": "^2.3.1",
-                "uuid": "^8.3.2"
-            }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.208.0.tgz",
-            "integrity": "sha512-lFVodZHYLF7puXgNZ1m5ycKbyCPp79nqI+pkRXl066ZtZWzCW8+JKCaLjF3jfXlnvg6foPDJdxUvt0VU5EddGg==",
-            "requires": {
-                "@aws-sdk/middleware-signing": "3.208.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/signature-v4": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-serde": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.208.0.tgz",
-            "integrity": "sha512-3h2yP6qyf/IhfdvyFeNX7w4BF37vOZvfUDBq+wb1QEc7DCAskoUKWtCCKJ9HDq3IJQp8hzqY82eawUir6flqlQ==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-signing": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.208.0.tgz",
-            "integrity": "sha512-cMSWhg8xOrxZw04EYKEQQQ7RT+03rigS4KS3Uy6x/M+jFyoM+sRiY/7376sJCwlpvKH2xJIVpwPbKk/uz4j4DA==",
-            "requires": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/signature-v4": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-stack": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.208.0.tgz",
-            "integrity": "sha512-bvFPUa+RTB7PSRCUsO6bRlEtiEadrDES+dpNmInMNQ9kmbd4OhNOCb664hhtiglIIXX5cd8mSPEo+w/RV0kEEQ==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/middleware-user-agent": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.208.0.tgz",
-            "integrity": "sha512-6RNf+TOZpiCy7xUcDSh8ji/x8ht1oAM+qIhm6hsEPLdI1cTvbPZrwowO9Y6L0J68V9OkEgLYiq77KKKYT7QQSw==",
-            "requires": {
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/node-config-provider": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.209.0.tgz",
-            "integrity": "sha512-jNrUn8qTN9BIxHCcLTv2s2h8Riaz4kjwDhubVQNyI0WGZ+PYKATnZjA+Guzbnq2WMzZmwrMIE5GoOiVsPD8xYQ==",
-            "requires": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/node-http-handler": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.208.0.tgz",
-            "integrity": "sha512-2t0b9Id7WekluqxQdPugAZhe/wdzW0L53rfMEfDS3R0INNSq1sEfddIfCzJrmfWDCrCOGIDNyxo/w7Ki3NclzQ==",
-            "requires": {
-                "@aws-sdk/abort-controller": "3.208.0",
-                "@aws-sdk/protocol-http": "3.208.0",
-                "@aws-sdk/querystring-builder": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/property-provider": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.208.0.tgz",
-            "integrity": "sha512-aUhfuwXjZ5TGzLhBstuAMmbnxHXeSGhzoIS8yy465ifgc95p6cHFZf+ZibgwgCMaGrKlTDCia2zwwpKQHN+4cw==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/protocol-http": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.208.0.tgz",
-            "integrity": "sha512-Sr9dmaW0Z9X9s16NHZn94efLRpaqLyLqABFPgjqE8cYP6eLX/VrmZGNR62GFVxCiyEEpVxy4Ddk1YkbRwnuonA==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/querystring-builder": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.208.0.tgz",
-            "integrity": "sha512-1Rpauh5hWlK++KjsHQjHcSN7yE05hj1FVb0HaeLrFIJB5rQYWXK7DpOUhmv5SOmU+q6cIM2kNCrSxH31+WglMw==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-uri-escape": "3.201.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/querystring-parser": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.208.0.tgz",
-            "integrity": "sha512-dVVLdP3il9bJX74/BNBjFn59XrEVBUZ4xSKYH6t7dgSz9uSu8DcT4pPzwaq+/94dVewCW3zq2jVA1iw1rK7JVQ==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/service-error-classification": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.208.0.tgz",
-            "integrity": "sha512-ZZWV3AOTd8UDcfXCNoQ8v4sHaTgFxGaXWO0NHHgqFbVYr1d+8EXQiOy/v8JsY1jrfoXBWXptTOcioCTeM0xBpw=="
-        },
-        "@aws-sdk/shared-ini-file-loader": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.209.0.tgz",
-            "integrity": "sha512-hji3B/q3zFuElaUQM/ZZUFbCFBsaVjpWATgiDTnSYP+MShWvvwm/WigeC2aCNos1bs/8HVizOy9cmvK63vLZbw==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/signature-v4": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.208.0.tgz",
-            "integrity": "sha512-+c5A8RsN4Lk3TXFiQ3ZsW7sJ4zYPPmYQ55ITSfjock5hzgM1vW43Mgvjjq6foW5L7SNfdhLH+NrhpgFwSF/GeA==",
-            "requires": {
-                "@aws-sdk/is-array-buffer": "3.201.0",
-                "@aws-sdk/types": "3.208.0",
-                "@aws-sdk/util-hex-encoding": "3.201.0",
-                "@aws-sdk/util-middleware": "3.208.0",
-                "@aws-sdk/util-uri-escape": "3.201.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/smithy-client": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.209.0.tgz",
-            "integrity": "sha512-+d9lPAFOu3hZdLfyzMurRU6xZ+eqwKbF6HY7mDL4hGafRb/uw28HBncSwyUk5s7MIND9+RnvY4F/MwBq9wznXg==",
-            "requires": {
-                "@aws-sdk/middleware-stack": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/token-providers": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.211.0.tgz",
-            "integrity": "sha512-dxdUT+JKCl9krmBQde1HeV6rwYP+ZTBkfx5vIa3PdfDI7XljRBf1XdE0mS18eSURfQA7v969Y5sJ6/rFyjT/QA==",
-            "requires": {
-                "@aws-sdk/client-sso-oidc": "3.211.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/shared-ini-file-loader": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/types": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.208.0.tgz",
-            "integrity": "sha512-5AuOPtY1Hdf4xoEo+voRijl3OnFm8IB+oITXl+SN2iASJv+XPnRNw/QVbIxfGeWgWhmK31F+XdjTYsjT2rx8Qw=="
-        },
-        "@aws-sdk/url-parser": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.208.0.tgz",
-            "integrity": "sha512-zhU231xkZbUh68Z/TGNRW30MGTZQVigGuMiJU6eOtL2aOulnKqI1Yjs/QejrTtPWsqSihWvxOUZ2cVRPyeOvrA==",
-            "requires": {
-                "@aws-sdk/querystring-parser": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-base64": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
-            "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-            "requires": {
-                "@aws-sdk/util-buffer-from": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-body-length-browser": {
-            "version": "3.188.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-            "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-body-length-node": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
-            "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-buffer-from": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
-            "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-            "requires": {
-                "@aws-sdk/is-array-buffer": "3.201.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-config-provider": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
-            "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-defaults-mode-browser": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.209.0.tgz",
-            "integrity": "sha512-c+AlHqsgeDr9+87fS1wfnyVzEH3myt56GvNt0puzIv0QQqfpobMnfN8/Fy0cqMpf1eQNYY4a6lFlkComsXi5dw==",
-            "requires": {
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-defaults-mode-node": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.209.0.tgz",
-            "integrity": "sha512-RljPVLog6EX052DQjx4XQ95n7ZiAbmn7Vd6YSn1x93U797umaC5CnrT7a/WusTQACtxBDFWcosRgO1ZGDXuRKQ==",
-            "requires": {
-                "@aws-sdk/config-resolver": "3.209.0",
-                "@aws-sdk/credential-provider-imds": "3.209.0",
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/property-provider": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-endpoints": {
-            "version": "3.211.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.211.0.tgz",
-            "integrity": "sha512-FY0h897WFltaUBF5aedLCBP2OlxN0aIqrInAa7aYGz3HsUTl97liHTii34bZrMJQHxmfcKBXAsjV1jJGc2orLw==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-hex-encoding": {
-            "version": "3.201.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
-            "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-locate-window": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
-            "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-middleware": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.208.0.tgz",
-            "integrity": "sha512-oXilrYpXwaPyMw1uNjL1wmR54zeFzIWx2ve1MSMheIYr26deFP3RpMfKkGXwiOvXzZ9pzTcA8shNLhg1frO/zg==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-uri-escape": {
-            "version": "3.201.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
-            "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.208.0.tgz",
-            "integrity": "sha512-Z5n9Kg2pBstzzQgRymQRgb4pM0bNPLGQejB3ZmCAphaxvuTBfu2E6KO55h5WwkFHUuh0i5u2wn1BI9R66S8CgQ==",
-            "requires": {
-                "@aws-sdk/types": "3.208.0",
-                "bowser": "^2.11.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-user-agent-node": {
-            "version": "3.209.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.209.0.tgz",
-            "integrity": "sha512-lWfvnSX8rckMGaalrKZmBlPW7F0QOviG7XbLffwToN4HnYUyXcZXIE4EzOQzuOvDsOUlos/xLkUj6krdIAApcA==",
-            "requires": {
-                "@aws-sdk/node-config-provider": "3.209.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-utf8-browser": {
-            "version": "3.188.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-            "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-            "requires": {
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-utf8-node": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-            "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-            "requires": {
-                "@aws-sdk/util-buffer-from": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
-        "@aws-sdk/util-waiter": {
-            "version": "3.208.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.208.0.tgz",
-            "integrity": "sha512-DEMVnoZXLUXeakBDMe9IhZ8VQCVf/5cMlNtE+4EpSVvH8CEE0Qfc0nDjrTYEkLpAIZWRL3tpHx61MMKvgCirXA==",
-            "requires": {
-                "@aws-sdk/abort-controller": "3.208.0",
-                "@aws-sdk/types": "3.208.0",
-                "tslib": "^2.3.1"
-            }
-        },
         "@babel/code-frame": {
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -7844,27 +6003,27 @@
             }
         },
         "@babel/compat-data": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.4.tgz",
-            "integrity": "sha512-CHIGpJcUQ5lU9KrPHTjBMhVwQG6CQjxfg36fGXl3qk/Gik1WwWachaXFuo0uCWJT/mStOKtcbFJCaVLihC1CMw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.1.tgz",
+            "integrity": "sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.3.tgz",
-            "integrity": "sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.2.tgz",
+            "integrity": "sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==",
             "dev": true,
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.3",
-                "@babel/helper-compilation-targets": "^7.19.3",
-                "@babel/helper-module-transforms": "^7.19.0",
-                "@babel/helpers": "^7.19.0",
-                "@babel/parser": "^7.19.3",
+                "@babel/generator": "^7.20.2",
+                "@babel/helper-compilation-targets": "^7.20.0",
+                "@babel/helper-module-transforms": "^7.20.2",
+                "@babel/helpers": "^7.20.1",
+                "@babel/parser": "^7.20.2",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.3",
-                "@babel/types": "^7.19.3",
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -7873,12 +6032,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.19.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.19.5.tgz",
-            "integrity": "sha512-DxbNz9Lz4aMZ99qPpO1raTbcrI1ZeYh+9NR9qhfkQIbFtVEqotHojEBxHzmxhVONkGt6VyrqVQcgpefMy9pqcg==",
+            "version": "7.20.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.4.tgz",
+            "integrity": "sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.19.4",
+                "@babel/types": "^7.20.2",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "jsesc": "^2.5.1"
             },
@@ -7897,12 +6056,12 @@
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.19.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.3.tgz",
-            "integrity": "sha512-65ESqLGyGmLvgR0mst5AdW1FkNlj9rQsCKduzEoEPhBCDFGXvz2jW6bXFG6i0/MrV2s7hhXjjb2yAzcPuQlLwg==",
+            "version": "7.20.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
+            "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.19.3",
+                "@babel/compat-data": "^7.20.0",
                 "@babel/helper-validator-option": "^7.18.6",
                 "browserslist": "^4.21.3",
                 "semver": "^6.3.0"
@@ -7943,34 +6102,34 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz",
-            "integrity": "sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
+            "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
             "dev": true,
             "requires": {
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-module-imports": "^7.18.6",
-                "@babel/helper-simple-access": "^7.18.6",
+                "@babel/helper-simple-access": "^7.20.2",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/helper-validator-identifier": "^7.18.6",
+                "@babel/helper-validator-identifier": "^7.19.1",
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.0",
-                "@babel/types": "^7.19.0"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.2"
             }
         },
         "@babel/helper-plugin-utils": {
-            "version": "7.19.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-            "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+            "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
             "dev": true
         },
         "@babel/helper-simple-access": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz",
-            "integrity": "sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+            "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.19.4"
+                "@babel/types": "^7.20.2"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -8001,14 +6160,14 @@
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.19.4.tgz",
-            "integrity": "sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.1.tgz",
+            "integrity": "sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==",
             "dev": true,
             "requires": {
                 "@babel/template": "^7.18.10",
-                "@babel/traverse": "^7.19.4",
-                "@babel/types": "^7.19.4"
+                "@babel/traverse": "^7.20.1",
+                "@babel/types": "^7.20.0"
             }
         },
         "@babel/highlight": {
@@ -8081,9 +6240,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
-            "integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==",
+            "version": "7.20.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.3.tgz",
+            "integrity": "sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==",
             "dev": true
         },
         "@babel/plugin-syntax-async-generators": {
@@ -8206,27 +6365,27 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.4.tgz",
-            "integrity": "sha512-w3K1i+V5u2aJUOXBFFC5pveFLmtq1s3qcdDNC2qRI6WPBQIDaKFqXxDEqDO/h1dQ3HjsZoZMyIy6jGLq0xtw+g==",
+            "version": "7.20.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.1.tgz",
+            "integrity": "sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.18.6",
-                "@babel/generator": "^7.19.4",
+                "@babel/generator": "^7.20.1",
                 "@babel/helper-environment-visitor": "^7.18.9",
                 "@babel/helper-function-name": "^7.19.0",
                 "@babel/helper-hoist-variables": "^7.18.6",
                 "@babel/helper-split-export-declaration": "^7.18.6",
-                "@babel/parser": "^7.19.4",
-                "@babel/types": "^7.19.4",
+                "@babel/parser": "^7.20.1",
+                "@babel/types": "^7.20.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             }
         },
         "@babel/types": {
-            "version": "7.19.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.4.tgz",
-            "integrity": "sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==",
+            "version": "7.20.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+            "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
             "dev": true,
             "requires": {
                 "@babel/helper-string-parser": "^7.19.4",
@@ -8490,9 +6649,9 @@
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.16",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.16.tgz",
-            "integrity": "sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==",
+            "version": "0.3.17",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
             "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "3.1.0",
@@ -8500,9 +6659,9 @@
             }
         },
         "@sinonjs/commons": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
-            "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.5.tgz",
+            "integrity": "sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==",
             "dev": true,
             "requires": {
                 "type-detect": "4.0.8"
@@ -8524,9 +6683,9 @@
             "dev": true
         },
         "@types/babel__core": {
-            "version": "7.1.19",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
-            "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
+            "version": "7.1.20",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.20.tgz",
+            "integrity": "sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==",
             "dev": true,
             "requires": {
                 "@babel/parser": "^7.1.0",
@@ -8598,9 +6757,9 @@
             }
         },
         "@types/node": {
-            "version": "18.8.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.8.5.tgz",
-            "integrity": "sha512-Bq7G3AErwe5A/Zki5fdD3O6+0zDChhg671NfPjtIcbtzDNZTv4NPKMRFr7gtYPG7y+B8uTiNK4Ngd9T0FTar6Q==",
+            "version": "18.11.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+            "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -8643,9 +6802,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true
         },
         "acorn-globals": {
@@ -8884,11 +7043,6 @@
                 }
             }
         },
-        "bowser": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -8971,9 +7125,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001419",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001419.tgz",
-            "integrity": "sha512-aFO1r+g6R7TW+PNQxKzjITwLOyDhVRLjW0LcwS/HCZGUUKTGNp9+IwLC4xyDSZBygVL/mxaFR3HIV6wEKQuSzw==",
+            "version": "1.0.30001431",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
+            "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
             "dev": true
         },
         "capture-exit": {
@@ -9304,9 +7458,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.282",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.282.tgz",
-            "integrity": "sha512-Dki0WhHNh/br/Xi1vAkueU5mtIc9XLHcMKB6tNfQKk+kPG0TEUjRh5QEMAUbRp30/rYNMFD1zKKvbVzwq/4wmg==",
+            "version": "1.4.284",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
             "dev": true
         },
         "emittery": {
@@ -9601,14 +7755,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
-        },
-        "fast-xml-parser": {
-            "version": "4.0.11",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-            "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-            "requires": {
-                "strnum": "^1.0.5"
-            }
         },
         "fb-watchman": {
             "version": "2.0.2",
@@ -9936,9 +8082,9 @@
             }
         },
         "is-core-module": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-            "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+            "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -10345,9 +8491,9 @@
             }
         },
         "jest-pnp-resolver": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-            "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+            "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
             "dev": true,
             "requires": {}
         },
@@ -10776,14 +8922,6 @@
                 "is-extendable": "^1.0.1"
             }
         },
-        "mnemonist": {
-            "version": "0.38.3",
-            "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
-            "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-            "requires": {
-                "obliterator": "^1.6.1"
-            }
-        },
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10986,11 +9124,6 @@
             "requires": {
                 "isobject": "^3.0.1"
             }
-        },
-        "obliterator": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-            "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
         },
         "once": {
             "version": "1.4.0",
@@ -11926,9 +10059,9 @@
             "dev": true
         },
         "stack-utils": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-            "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
             "dev": true,
             "requires": {
                 "escape-string-regexp": "^2.0.0"
@@ -12059,11 +10192,6 @@
             "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true
-        },
-        "strnum": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-            "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
         },
         "supports-color": {
             "version": "7.2.0",
@@ -12197,11 +10325,6 @@
                 "punycode": "^2.1.1"
             }
         },
-        "tslib": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
-        },
         "type-check": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -12333,7 +10456,9 @@
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "optional": true
         },
         "v8-to-istanbul": {
             "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "scripts": {
         "test": "jest",
         "start": "sam local start-api --warm-containers EAGER --docker-network utils_sam_bridge",
-        "deploy": "sam deploy"
-    },
-    "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.211.0"
+        "deploy": "sam deploy",
+        "build": "sam build"
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -1,130 +1,20 @@
-# This is the SAM template that represents the architecture of your serverless application
-# https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-template-basics.html
-
-# The AWSTemplateFormatVersion identifies the capabilities of the template
-# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/format-version-structure.html
 AWSTemplateFormatVersion: '2010-09-09'
-Description: >-
-  back-end
-
-# Transform section specifies one or more macros that AWS CloudFormation uses to process your template
-# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/transform-section-structure.html
-Transform:
-- AWS::Serverless-2016-10-31
+Transform: AWS::Serverless-2016-10-31
 
 Resources:
-
-  # ##############################################################################
-  # Front End
-  myDistribution:
-    Type: AWS::CloudFront::Distribution
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function 
     Properties:
-      DistributionConfig:
-        Origins:
-          - DomainName: !Join ['', [!Ref StaticBucket, '.s3.amazonaws.com']]
-            Id: static-bucket
-            S3OriginConfig:
-              OriginAccessIdentity: 
-                !Join ['', ['origin-access-identity/cloudfront/', !Ref CloudFrontOriginAccessIdentity]]
-          - Id: api-gateway
-            DomainName: !Sub "${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com"
-            CustomOriginConfig:
-              HTTPSPort: '443'
-              OriginProtocolPolicy: https-only
-            OriginPath: /Prod
-        DefaultCacheBehavior:
-          Compress: true
-          ForwardedValues:
-            QueryString: false
-          TargetOriginId: static-bucket
-          ViewerProtocolPolicy: redirect-to-https
-        CacheBehaviors:
-          - TargetOriginId: api-gateway
-            PathPattern: /api/*
-            ViewerProtocolPolicy: redirect-to-https
-            AllowedMethods:
-              - GET
-              - HEAD
-              - OPTIONS
-              - PUT
-              - PATCH
-              - POST
-              - DELETE
-            ForwardedValues:
-              QueryString: true
-        DefaultRootObject: index.html
-        Enabled: true
-        HttpVersion: http2
-        PriceClass: PriceClass_100
-        ViewerCertificate:
-          CloudFrontDefaultCertificate: true
-
-  CloudFrontOriginAccessIdentity:
-    Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
-    Properties:
-      CloudFrontOriginAccessIdentityConfig:
-        Comment: 'CloudFront OAI for Static App'
-  StaticBucket:
-    Type: 'AWS::S3::Bucket'
-  BucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref StaticBucket
-      PolicyDocument:
-        Statement:
-          - Action:
-              - s3:GetObject 
-            Effect: Allow
-            Resource: !Join ['', ['arn:aws:s3:::', !Ref StaticBucket, '/*']]
-            Principal:
-              CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
-
-  helloFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: src/handlers/hello.helloHandler
+      CodeUri: hello-world/
+      Handler: app.lambdaHandler
       Runtime: nodejs16.x
-      Timeout: 10
+      Architectures:
+        - x86_64
       Events:
-        Api:
-          Type: Api
+        HelloWorld:
+          Type: Api #
           Properties:
-            Path: /api/hello
-            Method: GET
-  messageFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: src/handlers/message.messageHandler
-      Runtime: nodejs16.x
-      Timeout: 10
-      Events:
-        Api:
-          Type: Api
-          Properties:
-            Path: /api/message
-            Method: POST
-  productsFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      Handler: src/handlers/products.rootHandler
-      Runtime: nodejs16.x
-      Timeout: 10
-      Events:
-        Api:
-          Type: Api
-          Properties:
-            Path: /api/products
-            Method: GET
-
-Outputs:
-  WebEndpoint:
-    Description: "API Gateway endpoint URL for Prod stage"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
-  S3BucketSecureURL:
-    Value: !Join 
-      - ''
-      - - 'https://'
-        - !GetAtt 
-          - StaticBucket
-          - DomainName
-    Description: Name of S3 bucket to hold website content
+            Path: /hello
+            Method: get
+    Metadata:
+      BuildMethod: esbuild 


### PR DESCRIPTION
Adding in updates for esbuild per suggestions from @mildaniel. These absolutely solve the problem of v3 sdk not working. But, with esbuild in, sam build has to be run with every code change. This makes sam local start-api effectively useless because having a .aws-sam build present disables hot-reloading.